### PR TITLE
Use SourceSets alone to configure input .java files

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
@@ -22,7 +22,7 @@ class J2objcNativeCompilation {
                 // For example task 'compileDebugTestJ2objcExecutableTestJ2objcObjc' compiles the debug
                 // buildType of the executable binary 'testJ2objc' from the 'testJ2objc' component.
                 if ((task.name =~ /^compile.*Objc$/).matches()) {
-                    task.dependsOn j2objcTranslate
+                    task.dependsOn 'j2objcTranslate'
                 }
             }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
@@ -83,7 +83,9 @@ class J2objcXcodeTask extends DefaultTask {
         String j2objcResourceDirPath = "${project.buildDir}/${j2objcResourceDirName}"
         project.delete j2objcResourceDirPath
         project.copy {
-            from J2objcUtils.srcDirs(project, 'main', 'resources')
+            J2objcUtils.srcDirs(project, 'main', 'resources').srcDirs.each {
+                from it
+            }
             into j2objcResourceDirPath
         }
 


### PR DESCRIPTION
Use SourceSets alone to configure input .java files
- Translation takes main and test java sourceSets
- Translation can be filtered using j2objcConfig.translatePattern
- Test takes test java sourceSet
- Test execution can be filtered using j2objcConfig.testPattern
- Cycle finder is analogous to translation.
- Also makes translation dependent on all possible input files.
- Prohibits incremental translation with --build-closure.

Fixes #57; Fixes #52; Fixes #95
Improves #85