### PR TITLE
added --static-accessor-methods to translateFlags

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
@@ -59,7 +59,7 @@ class J2objcPluginExtension {
     // A list of all possible flag can be found here
     // https://github.com/google/j2objc/blob/master/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC
     // .properties
-    String translateFlags = "--no-package-directories"
+    String translateFlags = "--no-package-directories --static-accessor-methods"
     // -classpath library additions from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar"
     String[] translateClassPaths = []
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
@@ -57,8 +57,7 @@ class J2objcPluginExtension {
     // TRANSLATE
     // Flags copied verbatim to j2objc command
     // A list of all possible flag can be found here
-    // https://github.com/google/j2objc/blob/master/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC
-    // .properties
+    // https://github.com/google/j2objc/blob/master/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
     String translateFlags = "--no-package-directories --static-accessor-methods"
     // -classpath library additions from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar"
     String[] translateClassPaths = []


### PR DESCRIPTION
--static-accessor-methods should be a default because it is a must have to use generated Enums with Swift. Makes access very easy.