### PR TITLE
Remove all translate flags defaults,

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
@@ -59,7 +59,7 @@ class J2objcPluginExtension {
     // A list of all possible flag can be found here
     // https://github.com/google/j2objc/blob/master/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC
     // .properties
-    String translateFlags = "--no-package-directories"
+    String translateFlags = ""
     // -classpath library additions from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar"
     String[] translateClassPaths = []
 


### PR DESCRIPTION
including --no-package-directories
to be consistent with j2objc.

moved thread here @confile @brunobowden.  argument remains the same, namely:
I see no compelling reason our defaults should be unequal to j2objc.
Consider a user migrating from j2objc scripts to the plugin.  The principle
of least surprise would dictate that the defaults in the plugin would be as
close to the binary as possible.

In this case, for example, when I first used the plugin I was confused because all my files were now flat.
It can also cause problems if I for example had two classes with different package prefixes in different packages.  A default --no-package-directories would cause a name conflict, while in the default state everything builds fine.

