### PR TITLE
arm64, armv7, armv7s architecture targets

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
@@ -114,8 +114,6 @@ class J2objcPluginExtension {
 
 
     // TEST
-    // Skip test task if true
-    boolean testSkip = false
     // Flags copied verbatim to testrunner command
     String testFlags = ""
     // Error if it runs less than the expected number of tests, set to 0 to disable.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
@@ -29,9 +29,13 @@ class J2objcPackLibrariesTask extends DefaultTask {
     // Generated ObjC binaries
     @InputFiles
     def getInputLibraries() {
+        def staticLibraryPath = "${project.buildDir}/binaries/${project.name}-j2objcStaticLibrary"
         return project.files([
-                "$inputStaticLibraryPath/ios_i386$buildType/lib${project.name}-j2objc.a",
-                "$inputStaticLibraryPath/ios_x86_64$buildType/lib${project.name}-j2objc.a",
+                "$staticLibraryPath/ios_arm64$buildType/lib${project.name}-j2objc.a",
+                "$staticLibraryPath/ios_armv7$buildType/lib${project.name}-j2objc.a",
+                "$staticLibraryPath/ios_armv7s$buildType/lib${project.name}-j2objc.a",
+                "$staticLibraryPath/ios_i386$buildType/lib${project.name}-j2objc.a",
+                "$staticLibraryPath/ios_x86_64$buildType/lib${project.name}-j2objc.a",
         ])
     }
 
@@ -40,13 +44,9 @@ class J2objcPackLibrariesTask extends DefaultTask {
         return project.file("${project.buildDir}/packedBinaries/${project.name}-j2objcStaticLibrary/ios$buildType")
     }
 
+    // Debug or Release for each library
     @Input
     String buildType
-
-    // Not an @Input, because it is used only in getInputLibraries.
-    def getInputStaticLibraryPath() {
-        return "${project.buildDir}/binaries/${project.name}-j2objcStaticLibrary"
-    }
 
     @TaskAction
     def lipoLibraries() {

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
@@ -94,11 +94,9 @@ class J2objcXcodeTask extends DefaultTask {
         // File("${project.buildDir}/j2objc") => "j2objc/"
 
         // podspec creation
-        // TODO s.libraries: this will not function for anyone who has their own list of linked libraries in the
-        // compileFlags
-        // Line separator assumed to be "\n" as this task can only be run on a Mac
+        // TODO: allow custom list of libraries
         // TODO: Need to specify the release and debug library search paths separately.
-        // Need to hook this up to the outputs of J2objcAssembleTask some how.
+        // Line separator assumed to be "\n" as this task can only be run on a Mac
         String podspecFileContents =
                 "Pod::Spec.new do |s|\n" +
                 "s.name = '${getPodName()}'\n" +
@@ -109,9 +107,9 @@ class J2objcXcodeTask extends DefaultTask {
                 "s.resources = '${j2objcResourceDirName}/**/*'\n" +
                 "s.requires_arc = true\n" +
                 "s.preserve_path = '${project.buildDir}/j2objc/*.a'\n" +
-                "s.libraries = 'ObjC', 'guava', 'javax_inject', 'jre_emul', 'jsr305', 'z', 'icucore', 'j2objc-generated-library'\n" +
+                "s.libraries = 'ObjC', 'guava', 'javax_inject', 'jre_emul', 'jsr305', 'z', 'icucore', '${project.name}-j2objc'\n" +
                 "s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${getJ2ObjCHome()}/include', " +
-                "'LIBRARY_SEARCH_PATHS' => '${getJ2ObjCHome()}/lib ${project.buildDir}/j2objc' }\n" +
+                "'LIBRARY_SEARCH_PATHS' => '${getJ2ObjCHome()}/lib ${project.buildDir}/j2objcOutputs/lib/iosDebug' }\n" +
                 "end\n"
         logger.debug "podspecFileContents creation...\n\n" + podspecFileContents
         File podspecFile = getPodspecFile()


### PR DESCRIPTION
Dependencies:
- j2objcTest dependsOn test (java plugin task)
- j2objcAssemble no longer dependsOn j2objcTest
- j2objcXcode dependsOn j2objcAssemble

Other:
- podspec debug library support
- j2objcHackToForceCompilation to better indicate purpose
- inline getInputStaticLibraryPath() as it's only used one place
- update list of main j2objc tasks