### PR TITLE
Copyright header, import empty gap lines, class descriptions

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
@@ -1,4 +1,21 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.j2objccontrib.j2objcgradle
+
 import com.github.j2objccontrib.j2objcgradle.tasks.J2objcUtils
 import groovy.transform.PackageScope
 import org.gradle.api.InvalidUserDataException
@@ -7,8 +24,9 @@ import org.gradle.nativeplatform.NativeExecutableSpec
 import org.gradle.nativeplatform.NativeLibraryBinary
 import org.gradle.nativeplatform.NativeLibrarySpec
 import org.gradle.nativeplatform.toolchain.Clang
+
 /**
- *
+ * Compilation of libraries for debug/release and architectures listed below.
  */
 class J2objcNativeCompilation {
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -15,6 +15,7 @@
  */
 
 package com.github.j2objccontrib.j2objcgradle
+
 import com.github.j2objccontrib.j2objcgradle.tasks.J2objcAssembleTask
 import com.github.j2objccontrib.j2objcgradle.tasks.J2objcCycleFinderTask
 import com.github.j2objccontrib.j2objcgradle.tasks.J2objcPackLibrariesTask
@@ -27,10 +28,10 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
-/*
- * Usage:
- */
 
+/*
+ * Main plugin class for creation of extension object and all the tasks.
+ */
 class J2objcPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
@@ -147,7 +148,7 @@ class J2objcPlugin implements Plugin<Project> {
             tasks.create(name: 'j2objcAssemble', type: J2objcAssembleTask,
                     dependsOn: ['j2objcPackLibrariesDebug', 'j2objcPackLibrariesRelease', 'j2objcTranslate']) {
                 group 'build'
-                description 'Copies final generated source after testing to assembly directories'
+                description 'Copies final generated source and libraries to assembly directories'
                 srcGenDir = j2objcSrcGenDir
                 libDir = file("${buildDir}/binaries/${project.name}-j2objcStaticLibrary")
                 packedLibDir = file("${buildDir}/packedBinaries/${project.name}-j2objcStaticLibrary")

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcAssembleTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcAssembleTask.groovy
@@ -15,14 +15,17 @@
  */
 
 package com.github.j2objccontrib.j2objcgradle.tasks
+
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+
 /**
- *
+ * Assemble task copies generated source and libaries to assembly directories for
+ * use by an iOS application.
  */
 class J2objcAssembleTask extends DefaultTask {
 
@@ -33,6 +36,7 @@ class J2objcAssembleTask extends DefaultTask {
     // Generated ObjC binaries
     @InputDirectory
     File libDir
+
     @InputDirectory
     File packedLibDir
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
@@ -15,11 +15,13 @@
  */
 
 package com.github.j2objccontrib.j2objcgradle.tasks
+
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+
 /**
  * Uses 'lipo' binary to combine multiple architecture flavors of a library into a
  * single 'fat' library.


### PR DESCRIPTION
Correcting a number of items within file headers. Another commit will
finish the rest of the files.

- Add missing copyright header
- Empty lines between copyright header, package and imports
- Descriptions for every class