### PR TITLE
J2objcUtils: type checking + unit tests

### DIFF
--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle.tasks
+
+import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test;
+
+/**
+ * J2objcUtils tests.
+ */
+public class J2objcUtilsTest {
+
+    private Project proj
+
+    @Before
+    void setUp() {
+        proj = ProjectBuilder.builder().build()
+    }
+
+    @Test
+    public void testIsWindows() {
+        // TODO: also test for correctness
+        // For now it only tests that the call runs successfully
+        J2objcUtils.isWindows()
+    }
+
+    // TODO: testSrcDirs() - requires 'java' plugin
+
+    // TODO: testSourcepathJava() - requires 'java' plugin
+
+    // TODO: testJ2objcHome()
+
+    @Test
+    public void testPrefixProperties_FileOnly() {
+        // TODO: fix to use this.getClass().getResource(...) once Android Studio issue fixed
+        // https://code.google.com/p/android/issues/detail?id=75991
+        File prefixesProp = new File(
+                'src/test/resources/com/github/j2objccontrib/j2objcgradle/prefixes.properties')
+
+        List<String> translateArgs = new ArrayList<String>()
+        translateArgs.add("--prefixes ${prefixesProp.absolutePath}")
+        Properties properties = J2objcUtils.prefixProperties(proj, translateArgs)
+
+        Properties expected = new Properties()
+        expected.setProperty('com.example.parent', 'ParentPrefixesFile')
+        expected.setProperty('com.example.parent.subdir', 'SubdirPrefixesFile')
+        expected.setProperty('com.example.other', 'OtherPrefixesFile')
+
+        assert properties == expected
+    }
+
+    @Test
+    public void testPrefixProperties_FileAndArgs() {
+        // TODO: repeat as above
+        File prefixesProp = new File(
+                'src/test/resources/com/github/j2objccontrib/j2objcgradle/prefixes.properties')
+
+        List<String> translateArgs = new ArrayList<String>()
+        // prefix is overwritten by prefixes.properties
+        translateArgs.add('--prefix com.example.parent=ParentPrefixArg')
+        translateArgs.add("--prefixes ${prefixesProp.absolutePath}")
+        // prefix overwrites prefixes.properties
+        translateArgs.add('--prefix com.example.parent.subdir=SubdirPrefixArg')
+
+        Properties properties = J2objcUtils.prefixProperties(proj, translateArgs)
+
+        Properties expected = new Properties()
+        expected.setProperty('com.example.parent', 'ParentPrefixesFile')
+        expected.setProperty('com.example.parent.subdir', 'SubdirPrefixArg')
+        expected.setProperty('com.example.other', 'OtherPrefixesFile')
+
+        assert properties == expected
+    }
+
+    @Test
+    public void testFilenameCollisionCheck_NoCollisition() {
+        FileCollection files = proj.files('DiffOne.java', 'DiffTwo.java')
+        J2objcUtils.filenameCollisionCheck(files)
+    }
+
+    @Test(expected = InvalidUserDataException.class)
+    public void testFilenameCollisionCheck_Collision() {
+        // Same filename but located in different paths
+        FileCollection files = proj.files('dirOne/Same.java', 'dirTwo/Same.java')
+        J2objcUtils.filenameCollisionCheck(files)
+    }
+
+    // TODO: testAddJavaFiles()
+
+    @Test
+    public void testAbsolutePathOrEmpty() {
+        String path = J2objcUtils.absolutePathOrEmpty(proj, new ArrayList<String>(['One/', 'Two/']))
+
+        String absPath = proj.rootDir.absolutePath
+        assert path == ":$absPath/One:$absPath/Two".toString()
+    }
+
+    @Test
+    public void testAbsolutePathOrEmpty_Empty() {
+        String path = J2objcUtils.absolutePathOrEmpty(proj, new ArrayList<String>())
+
+        assert path == ''
+    }
+
+    @Test
+    public void testGetClassPathArg() {
+        String classPathArg = J2objcUtils.getClassPathArg(
+                proj, "/J2OBJC_HOME",
+                new ArrayList<String>(['LibOne', 'LibTwo']),
+                new ArrayList<String>(['J2LibOne', 'J2LibTwo']))
+
+        String absPath = proj.rootDir.absolutePath
+        assert classPathArg == "$absPath/LibOne:$absPath/LibTwo:/J2OBJC_HOME/lib/J2LibOne:/J2OBJC_HOME/lib/J2LibTwo".toString()
+    }
+
+    // TODO: testFilterJ2objcOutputForErrorLines()
+
+    @Test
+    public void testMatchNumberRegex() {
+        int count = J2objcUtils.matchNumberRegex("15 CYCLES FOUND", /(\d+) CYCLES FOUND/)
+        assert count == 15
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMatchNumberRegex_NoMatch() {
+        int count = J2objcUtils.matchNumberRegex("AA CYCLES FOUND", /(\d+) CYCLES FOUND/)
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMatchNumberRegex_NotNumber() {
+        int count = J2objcUtils.matchNumberRegex("AA CYCLES FOUND", /(.*) CYCLES FOUND/)
+    }
+}

--- a/src/test/resources/com/github/j2objccontrib/j2objcgradle/prefixes.properties
+++ b/src/test/resources/com/github/j2objccontrib/j2objcgradle/prefixes.properties
@@ -1,0 +1,3 @@
+com.example.parent: ParentPrefixesFile
+com.example.parent.subdir: SubdirPrefixesFile
+com.example.other: OtherPrefixesFile


### PR DESCRIPTION
Changes isolated to J2objcUtils, J2objcUtilsTest and test resource
- First unit tests for the plugin
- TODO’s for methods not unit tested
- Added prefixes.properties as test resource
- Replace many instances of “def” with explicit type
- Remove unused fileFilter(…) method
- Introduces unit tests - issue #98