### PR TITLE
Flags => Groovy Args, starting with translateArgs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -30,7 +30,7 @@ Add the following to your configuration block. [See](https://developer.apple.com
 
 ```
 j2objcConfig {
-   translateFlags '-use-arc'
+   translateArgs '-use-arc'
    extraObjcCompilerArgs += '-fobjc-arc'
 }
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ java project's build.gradle:
 Note that when rapidly developing and testing changes to the plugin by building your own project,
 avoid using the Gradle daemon as issues sometimes arise with the daemon using an old version
 of the plugin jar.  You can stop an existing daemon with `./gradlew --stop` and avoid the daemon
-on a particular build with the `--no-daemon` flag to gradlew.
+on a particular build with the `--no-daemon` argument to gradlew.
 
 
 ### Contributing

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
@@ -250,15 +250,15 @@ class J2objcNativeCompilation {
                 }
             }
 
-            // We need to run clang with the flags j2objcc would usually pass.
+            // We need to run clang with the arguments that j2objcc would usually pass.
             binaries.all {
                 // Only want to modify the Objective-C toolchain, not the JDK one.
                 if (toolChain in Clang) {
                     def j2objcPath = J2objcUtils.j2objcHome(project)
 
-                    // If you want to override the flags passed to the compiler and linker, you must configure
-                    // the binaries in your own build.gradle.  See
-                    // Gradle User Guide: 54.11. Configuring the compiler, assembler and linker
+                    // If you want to override the arguments passed to the compiler and linker,
+                    // you must configure the binaries in your own build.gradle.
+                    // See "Gradle User Guide: 54.11. Configuring the compiler, assembler and linker"
                     // https://docs.gradle.org/current/userguide/nativeBinaries.html#N16030
                     // TODO: Consider making this configuration easier using plugin extension.
                     // If we do that, however, we will become inconsistent with Gradle Objective-C building.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -61,14 +61,15 @@ class J2objcPlugin implements Plugin<Project> {
                     throw new InvalidUserDataException(message)
                 }
 
-                boolean arcTranslateArg = '-use-arc' in evaluatedProject.j2objcConfig.translateFlags
+                boolean arcTranslateArg = '-use-arc' in evaluatedProject.j2objcConfig.translateArgs
                 boolean arcCompilerArg = '-fobjc-arc' in evaluatedProject.j2objcConfig.extraObjcCompilerArgs
                 if (arcTranslateArg && !arcCompilerArg || !arcTranslateArg && arcCompilerArg) {
-                    logger.error "${evaluatedProject.name}: using ARC with J2ObjC, the project is missing one of the two flags required:\n" +
+                    logger.error "${evaluatedProject.name}: using ARC with J2ObjC, the project is missing one of the two arguments required:\n" +
                         "\n" +
                         "j2objcConfig {\n" +
                         "    // other settings\n" +
-                        "    translateFlags '-use-arc'\n" +
+                        "    translateArgs '-use-arc'\n" +
+                        // TODO: extraObjcCompilerArgs '-fobjc-arc'
                         "    extraObjcCompilerArgs = ['-fobjc-arc']\n" +
                         "}\n" +
                         "-fobjc-arc enables Automatic Reference Counting functionality in the compiler:\n" +

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.util.ConfigureUtil
+
 /**
  * Further configuration uses the following fields, setting them in j2objcConfig within build.gradle
  */
@@ -73,13 +74,15 @@ class J2objcPluginExtension {
      * main and/or test sourceSets.
      */
     String[] generatedSourceDirs = []
+    // TODO: void generatedSourceDirs(String... generatedSourceDirs) {
+
 
     // CYCLEFINDER
     /**
-     * Flags copied verbatim to cycle_finder command.
+     * Add command line arguments to cycle_finder command.
      */
-    // Warning will ask user to configure this within j2objcConfig.
-    String cycleFinderFlags = null
+    final List<String> cycleFinderArgs = new ArrayList<>()
+    // TODO: void cycleFinderArgs(String... cycleFinderArgs) {
     /**
      * Expected number of cycles, defaults to all those found in JRE.
      * <p/>
@@ -88,23 +91,40 @@ class J2objcPluginExtension {
     // TODO(bruno): convert to a default whitelist and change expected cyles to 0
     int cycleFinderExpectedCycles = 40
 
+
     // TRANSLATE
+    final List<String> translateArgs = new ArrayList<>()
     /**
-     * Flags copied verbatim to j2objc command.
+     * Add command line arguments for j2objc translate.
      * <p/>
-     * A list of all possible flag can be found here:
+     * A list of all possible arguments can be found here:
      * https://github.com/google/j2objc/blob/master/translator/src/main/resources/com/google/devtools/j2objc/J2ObjC.properties
+     *
+     * @param translateArgs args for the translate task
      */
-    String translateFlags = ""
+    // Provides a subset of "args" interface from project.exec as implemented by ExecHandleBuilder:
+    // https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/groovy/org/gradle/process/internal/ExecHandleBuilder.java
+    // Allows the following:
+    // j2objcConfig {
+    //     translateArgs '--no-package-directories', '--prefixes', 'prefixes.properties'
+    // }
+    void translateArgs(String... translateArgs) {
+        if (translateArgs == null) {
+            throw new IllegalArgumentException("args == null!");
+        }
+        this.translateArgs.addAll(Arrays.asList(translateArgs));
+    }
     /**
      * -classpath library additions from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar"
      */
     String[] translateClassPaths = []
+    // TODO: void translateClassPaths(String... translateClassPaths) {
+
 
     // Do not use groovydoc, this option should remain undocumented.
     // WARNING: Do not use this unless you know what you are doing.
     // If true, incremental builds will be supported even if --build-closure is included in
-    // translateFlags. This may break the build in unexpected ways if you change the dependencies
+    // translateArgs. This may break the build in unexpected ways if you change the dependencies
     // (e.g. adding new files or changing translateClassPaths). When you change the dependencies and
     // the build breaks, you need to do a clean build.
     boolean UNSAFE_incrementalBuildClosure = false
@@ -114,6 +134,7 @@ class J2objcPluginExtension {
      */
     // TODO: just import everything in the j2objc/lib/ directory?
     // J2objc default libraries, from $J2OBJC_HOME/lib/...
+    // TODO: void translateJ2objcLibs(String... translateJ2objcLibs) {
     String[] translateJ2objcLibs = [
             // Memory annotations, e.g. @Weak, @AutoreleasePool
             "j2objc_annotations.jar",
@@ -240,14 +261,16 @@ class J2objcPluginExtension {
      *
      * @see J2objcNativeCompilation#ALL_SUPPORTED_ARCHS
      */
+    // TODO: void supportedArchs(String... supportedArchs) {
     String[] supportedArchs = J2objcNativeCompilation.ALL_SUPPORTED_ARCHS.clone()
 
 
     // TEST
     /**
-     * Flags copied verbatim to testrunner command.
+     * Adds command line arguments for test executable.
      */
-    String testFlags = ""
+    final List<String> testArgs = new ArrayList<>()
+    // TODO: void testArgs(String... testArgs) {
     /**
      * j2objcTest will fail if it runs less than the expected number of tests; set to 0 to disable.
      * <p/>
@@ -295,14 +318,17 @@ class J2objcPluginExtension {
      * Directories of objective-c source to compile in addition to the
      * translated source.
      */
+    // TODO: void extraObjcSrcDirs(String... extraObjcSrcDirs) {
     String[] extraObjcSrcDirs = []
     /**
      * Additional arguments to pass to the objective-c compiler.
      */
+    // TODO: void extraObjcCompilerArgs(String... extraObjcCompilerArgs) {
     String[] extraObjcCompilerArgs = []
     /**
      * Additional arguments to pass to the native linker.
      */
+    // TODO: void extraLinkerArgs(String... extraLinkerArgs) {
     String[] extraLinkerArgs = []
 
     // XCODE

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTestTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTestTask.groovy
@@ -17,7 +17,6 @@
 package com.github.j2objccontrib.j2objcgradle.tasks
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
@@ -25,8 +24,6 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-
-import java.util.regex.Pattern
 
 /**
  *
@@ -58,10 +55,10 @@ class J2objcTestTask extends DefaultTask {
 
     // j2objcConfig dependencies for UP-TO-DATE checks
     @Input
-    String getTestFlags() { return project.j2objcConfig.testFlags }
+    List<String> getTestArgs() { return project.j2objcConfig.testArgs }
 
     @Input
-    String getTranslateFlags() { return project.j2objcConfig.translateFlags }
+    List<String> getTranslateArgs() { return project.j2objcConfig.translateArgs }
 
     @Input
     int getTestMinExpectedTests() { return project.j2objcConfig.testMinExpectedTests }
@@ -74,8 +71,8 @@ class J2objcTestTask extends DefaultTask {
         logger.debug "Test Binary: $binary"
 
         // list of test names: ['com.example.dir.ClassOneTest', 'com.example.dir.ClassTwoTest']
-        // depends on "--prefixes dir/prefixes.properties" in translateFlags
-        def testNames = testNames(project, getSrcFiles(), getTranslateFlags())
+        // depends on "--prefixes dir/prefixes.properties" in translateArgs
+        def testNames = testNames(project, getSrcFiles(), getTranslateArgs())
 
         def output = new ByteArrayOutputStream()
         try {
@@ -83,7 +80,7 @@ class J2objcTestTask extends DefaultTask {
                 executable binary
                 args "org.junit.runner.JUnitCore"
 
-                args getTestFlags().split()
+                args getTestArgs()
 
                 testNames.each { testName ->
                     args testName
@@ -108,7 +105,7 @@ class J2objcTestTask extends DefaultTask {
                     "    }\n" +
                     "}\n" +
                     "\n" +
-                    "To identify the failing test, run with the --debug flag and look for:\n" +
+                    "To identify the failing test, run with the --debug argument and look for:\n" +
                     "    testJ2objc org.junit.runner.JUnitCore\n" +
                     "Copy the command from \"Command:\" onwards, then try varying the command\n" +
                     "to drop tests and figure out which ones are causing the failures.\n"
@@ -174,9 +171,9 @@ class J2objcTestTask extends DefaultTask {
     // Generate Test Names
     // Generate list of tests from the source java files
     // e.g. src/test/java/com/example/dir/ClassTest.java => "com.example.dir.ClassTest"
-    // depends on --prefixes dir/prefixes.properties in translateFlags
-    def static testNames(Project proj, FileCollection srcFiles, String translateFlags) {
-        def prefixesProperties = J2objcUtils.prefixProperties(proj, translateFlags)
+    // depends on --prefixes dir/prefixes.properties in translateArgs
+    def static testNames(Project proj, FileCollection srcFiles, List<String> translateArgs) {
+        def prefixesProperties = J2objcUtils.prefixProperties(proj, translateArgs)
 
         def testNames = srcFiles.collect { file ->
             // src/test/java/com/example/dir/SomeTest.java => com.example.dir.SomeTest

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 import java.util.regex.Matcher
 
+import java.util.regex.Matcher
+
 /**
  * Internal utilities supporting plugin implementation.
  */

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtensionTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtensionTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.ConfigureUtil
+import org.junit.Before
+import org.junit.Test;
+
+/**
+ * J2objcPluginExtension tests.
+ */
+public class J2objcPluginExtensionTest {
+
+    private Project proj
+
+    @Before
+    void setUp() {
+        proj = ProjectBuilder.builder().build()
+    }
+
+    @Test
+    public void testConstructor() {
+        J2objcPluginExtension ext = new J2objcPluginExtension(proj)
+
+        assert ext.destSrcDir == proj.buildDir.absolutePath + '/j2objcOutputs/src/main/objc'
+        assert ext.destSrcDirTest == proj.buildDir.absolutePath + '/j2objcOutputs/src/test/objc'
+        assert ext.destLibDir == proj.buildDir.absolutePath + '/j2objcOutputs/lib'
+    }
+
+    @Test
+    public void testFinalConfigure() {
+        J2objcPluginExtension ext = new J2objcPluginExtension(proj)
+
+        assert !ext.finalConfigured
+        ext.finalConfigure()
+        assert ext.finalConfigured
+    }
+
+    @Test
+    public void testCycleFinderArgs_SimpleConfig() {
+        J2objcPluginExtension ext = new J2objcPluginExtension(proj)
+
+        ext.cycleFinderArgs.add('')
+
+        assert ext.cycleFinderArgs == new ArrayList<>([''])
+    }
+
+    @Test
+    public void testTranslateArgs() {
+        J2objcPluginExtension ext = new J2objcPluginExtension(proj)
+
+        // To test similarly to how it would be configured:
+        // j2objcConfig {
+        //      translateArgs '--no-package-directories'
+        //      translateArgs '--prefixes', 'prefixes.properties'
+        // }
+        ConfigureUtil.configure(
+                {
+                    translateArgs '--no-package-directories'
+                    translateArgs '--prefixes', 'prefixes.properties'
+                }, ext)
+
+        List<String> expected = new ArrayList<>(
+                ['--no-package-directories', '--prefixes', 'prefixes.properties'])
+        assert ext.translateArgs == expected
+    }
+}


### PR DESCRIPTION
Flags => Args:
- Partial fix for issue #204 (Groovy Like Args)
- Replace all mentions of Flags with Args (others are fixed in previous
PR’s)
- Change type from String or String[] to always be List<String>
- TODO’s for remaining work on this
- Allows for configuration which matches the Groovy "args" style:

```
j2objcConfig {
    translateArgs '--no-package-directories'
    translateArgs '--prefixes', 'prefixes.properties'
}
```
J2objcPluginExtensionTest:
- testing for constructor and finalConfigure()
- testTranslateArgs for the user syntax for the new args style

Other Changes:
- file header empty line spacing
- class description
- remove unused imports

TESTED=yes