### PR TITLE
Fix `plugins {...}` syntax by allowing reordering of plugin loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Tracked issue: https://github.com/j2objc-contrib/j2objc-gradle/issues/130**
         xcodeProjectDir "${projectDir}/../ios"   // Xcode workspace directory
         xcodeTarget "IosApp"                     // Xcode application target name
     
-        // More: https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy#L25
+        // Help information on other settings:
+        // https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPluginExtension.groovy#L25
         
-        // You must include this call (at the end of the block) even if you do not configure any other settings.
+        // You must include this call (at the end of j2objcConfig) regardless of settings
         finalConfigure()
     }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -37,20 +37,15 @@ class J2objcPlugin implements Plugin<Project> {
     void apply(Project project) {
         // This avoids a lot of "project." prefixes, such as "project.tasks.create"
         project.with {
-            if (!plugins.hasPlugin('java')) {
-                def message =
-                        "j2objc plugin didn't find the 'java' plugin in the '${project.name}' project.\n"+
-                        "This is a requirement for using j2objc. Please see usage information at:\n" +
-                        "\n" +
-                        "https://github.com/j2objc-contrib/j2objc-gradle/#usage"
-                throw new InvalidUserDataException(message)
-            }
-
             extensions.create('j2objcConfig', J2objcPluginExtension, project)
+
             afterEvaluate { evaluatedProject ->
+
                 // Validate minimally required parameters.
                 // j2objcHome() will throw the appropriate exception internally.
                 assert J2objcUtils.j2objcHome(evaluatedProject)
+
+                J2objcUtils.throwIfNoJavaPlugin(evaluatedProject)
 
                 if (!evaluatedProject.j2objcConfig.isFinalConfigured()) {
                     def message = "You must call finalConfigure() in j2objcConfig, ex:\n" +

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
@@ -40,8 +40,21 @@ class J2objcUtils {
         return System.getProperty('os.name').toLowerCase().contains('windows')
     }
 
+    static void throwIfNoJavaPlugin(Project proj) {
+        if (!proj.plugins.hasPlugin('java')) {
+            String message =
+                    "j2objc plugin didn't find the 'java' plugin in the '${proj.name}' project.\n" +
+                    "This is a requirement for using j2objc. Please see usage information at:\n" +
+                    "\n" +
+                    "https://github.com/j2objc-contrib/j2objc-gradle/#usage"
+            throw new InvalidUserDataException(message)
+        }
+    }
+
     // Retrieves the configured source directories from the Java plugin SourceSets.
     static SourceDirectorySet srcDirs(Project proj, String sourceSetName, String fileType) {
+        throwIfNoJavaPlugin(proj)
+
         assert fileType == 'java' || fileType == 'resources'
         assert sourceSetName == 'main' || sourceSetName == 'test'
         SourceSet sourceSet = proj.sourceSets.findByName(sourceSetName)

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
@@ -42,6 +42,13 @@ public class J2objcUtilsTest {
         J2objcUtils.isWindows()
     }
 
+    @Test(expected = InvalidUserDataException.class)
+    public void testThrowIfNoJavaPlugin_NoJavaPlugin() {
+        J2objcUtils.throwIfNoJavaPlugin(proj)
+    }
+
+    // TODO: testThrowIfNoJavaPlugin_JavaPluginExists
+
     // TODO: testSrcDirs() - requires 'java' plugin
 
     // TODO: testSourcepathJava() - requires 'java' plugin


### PR DESCRIPTION
- Creates new `throwIfNoJavaPlugin(…)` method
- Move the above check from `project.with` to `project.afterEvaluate`
- Add another check in `srcDirs(…)` method as a double check

This allows the `j2objc` to be loaded before the `java` plugin… but
still produces meaningful errors if the `java` plugin is missing. This
allows the use of the `plugins` syntax and should fix #130.

This will need to be verified after a new plugin is published. Likely
version 0.3.0.

    plugins {
        id "com.github.j2objccontrib.j2objcgradle" version "0.3.0-alpha"
    }

    apply 'java'