### PR TITLE
Add import mistakenly marked as unused

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcCycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcCycleFinderTask.groovy
@@ -178,6 +178,7 @@ class J2objcCycleFinderTask extends DefaultTask {
             def outputStr = output.toString()
             int cyclesFound = J2objcUtils.matchNumberRegex(outputStr, /(\d+) CYCLES FOUND/)
             if (cyclesFound != getCycleFinderExpectedCycles()) {
+                // Suppress exception when cycles found == cycleFinderExpectedCycles
                 logger.error outputStr
                 def message =
                         "Unexpected number of cycles founder:\n" +
@@ -191,7 +192,9 @@ class J2objcCycleFinderTask extends DefaultTask {
                         "}\n"
                 throw new Exception(message)
             }
-            // Suppress exception when cycles found == cycleFinderExpectedCycles
+
+            // rethrow unknown exception
+            throw exception
         }
 
         reportFile.write(output.toString())

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
@@ -23,8 +23,8 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 import java.util.regex.Matcher
-
-import java.util.regex.Matcher
+// TODO: import is used, Android Studio mistakenly marks it as unused
+import java.util.Properties
 
 /**
  * Internal utilities supporting plugin implementation.


### PR DESCRIPTION
- Android Studio mistakenly marks it as unused
- Remove redundant import
- Exception rethrow comment improvements