### PR TITLE
Explicit Types for `->` iterators, fixes #205

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcNativeCompilation.groovy
@@ -20,6 +20,7 @@ import com.github.j2objccontrib.j2objcgradle.tasks.J2objcUtils
 import groovy.transform.PackageScope
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.nativeplatform.NativeExecutableSpec
 import org.gradle.nativeplatform.NativeLibraryBinary
 import org.gradle.nativeplatform.NativeLibrarySpec
@@ -42,7 +43,7 @@ class J2objcNativeCompilation {
     def apply(File srcGenDir) {
         project.with {
             // Wire up dependencies with tasks created dynamically by native plugin(s).
-            tasks.whenTaskAdded { task ->
+            tasks.whenTaskAdded { Task task ->
                 // The Objective-C native plugin will add tasks of the form 'compile...Objc' for each
                 // combination of buildType, platform, and component.  Note that components having only
                 // one buildType or platform will NOT have the given buildType/platform in the task name, so
@@ -99,10 +100,10 @@ class J2objcNativeCompilation {
                                     '-arch',
                                     'arm64']
                             iosClangArgs += iphoneClangArgs
-                            objcCompiler.withArguments { args ->
+                            objcCompiler.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
                         }
@@ -111,10 +112,10 @@ class J2objcNativeCompilation {
                                     '-arch',
                                     'armv7']
                             iosClangArgs += iphoneClangArgs
-                            objcCompiler.withArguments { args ->
+                            objcCompiler.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
                         }
@@ -123,10 +124,10 @@ class J2objcNativeCompilation {
                                     '-arch',
                                     'armv7s']
                             iosClangArgs += iphoneClangArgs
-                            objcCompiler.withArguments { args ->
+                            objcCompiler.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
                         }
@@ -135,10 +136,10 @@ class J2objcNativeCompilation {
                                     '-arch',
                                     'i386']
                             iosClangArgs += simulatorClangArgs
-                            objcCompiler.withArguments { args ->
+                            objcCompiler.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
                         }
@@ -147,15 +148,15 @@ class J2objcNativeCompilation {
                                     '-arch',
                                     'x86_64']
                             iosClangArgs += simulatorClangArgs
-                            objcCompiler.withArguments { args ->
+                            objcCompiler.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 iosClangArgs.each { args << it }
                             }
                         }
                         target('x86_64') {
-                            linker.withArguments { args ->
+                            linker.withArguments { List<String> args ->
                                 args << '-framework'
                                 args << 'ExceptionHandling'
                             }
@@ -205,7 +206,7 @@ class J2objcNativeCompilation {
                                 }
                             }
                         }
-                        j2objcConfig.supportedArchs.each { arch ->
+                        j2objcConfig.supportedArchs.each { String arch ->
                             if (!(arch in ALL_SUPPORTED_ARCHS)) {
                                 def message = "Requested architecture $arch must be one of $ALL_SUPPORTED_ARCHS"
                                 throw new InvalidUserDataException(message)
@@ -217,7 +218,7 @@ class J2objcNativeCompilation {
 
                         // Resolve dependencies from all java j2objc projects using the compiled static libs.
                         binaries.all {
-                            beforeProjects.each { beforeProject ->
+                            beforeProjects.each { Project beforeProject ->
                                 lib project: beforeProject.path, library: "${beforeProject.name}-j2objc", linkage: 'static'
                             }
                         }
@@ -237,7 +238,7 @@ class J2objcNativeCompilation {
                         binaries.all {
                             lib library: "${project.name}-j2objc", linkage: 'static'
                             // Resolve dependencies from all java j2objc projects using the compiled static libs.
-                            beforeProjects.each { beforeProject ->
+                            beforeProjects.each { Project beforeProject ->
                                 lib project: beforeProject.path, library: "${beforeProject.name}-j2objc", linkage: 'static'
                             }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.logging.LogLevel
 
 
@@ -41,7 +42,7 @@ class J2objcPlugin implements Plugin<Project> {
         project.with {
             extensions.create('j2objcConfig', J2objcPluginExtension, project)
 
-            afterEvaluate { evaluatedProject ->
+            afterEvaluate { Project evaluatedProject ->
 
                 // Validate minimally required parameters.
                 // j2objcHome() will throw the appropriate exception internally.
@@ -178,7 +179,7 @@ class J2objcPlugin implements Plugin<Project> {
         // added in the future.
         // TODO: Find a better way to have afterTask depend on beforeTask, without
         // materializing afterTask early.
-        proj.tasks.all { task ->
+        proj.tasks.all { Task task ->
             if (task.name == afterTaskName) {
                 task.dependsOn beforeTaskName
             }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcCycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcCycleFinderTask.groovy
@@ -47,7 +47,7 @@ class J2objcCycleFinderTask extends DefaultTask {
     // All input files that could affect translation output, except those in j2objc itself.
     @InputFiles
     FileCollection getAllInputFiles() {
-        FileCollection allFiles = srcFiles
+        FileCollection allFiles = getSrcFiles()
         if (getTranslateSourcepaths()) {
             List<String> translateSourcepathPaths = getTranslateSourcepaths().split(':') as List<String>
             translateSourcepathPaths.each { String sourcePath ->
@@ -139,7 +139,7 @@ class J2objcCycleFinderTask extends DefaultTask {
         // vs. translate task.  Here they are directly passed to the binary, but in translate
         // they are only on the translate source path (meaning they will only be translated with --build-closure).
         FileCollection fullSrcFiles = J2objcUtils.addJavaFiles(
-                project, srcFiles, getGeneratedSourceDirs())
+                project, getSrcFiles(), getGeneratedSourceDirs())
         sourcepath += J2objcUtils.absolutePathOrEmpty(
                 project, getGeneratedSourceDirs())
 
@@ -166,7 +166,7 @@ class J2objcCycleFinderTask extends DefaultTask {
 
                 args getCycleFinderArgs()
 
-                fullSrcFiles.each { file ->
+                fullSrcFiles.each { File file ->
                     args file.path
                 }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcPackLibrariesTask.groovy
@@ -52,10 +52,10 @@ class J2objcPackLibrariesTask extends DefaultTask {
 
     @TaskAction
     void lipoLibraries() {
-        if (outputLibDir.exists()) {
+        if (getOutputLibDir().exists()) {
             // Clear it out.
-            outputLibDir.deleteDir()
-            outputLibDir.mkdirs()
+            getOutputLibDir().deleteDir()
+            getOutputLibDir().mkdirs()
         }
         ByteArrayOutputStream output = new ByteArrayOutputStream()
         try {
@@ -64,7 +64,7 @@ class J2objcPackLibrariesTask extends DefaultTask {
 
                 args 'lipo'
                 args '-create', '-output', "${outputLibDir}/lib${project.name}-j2objc.a"
-                inputLibraries.each { File libFile ->
+                getInputLibraries().each { File libFile ->
                     args libFile.absolutePath
                 }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTestTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTestTask.groovy
@@ -74,7 +74,7 @@ class J2objcTestTask extends DefaultTask {
 
         // list of test names: ['com.example.dir.ClassOneTest', 'com.example.dir.ClassTwoTest']
         // depends on "--prefixes dir/prefixes.properties" in translateArgs
-        Properties packagePrefixes = J2objcUtils.prefixProperties(project, translateArgs)
+        Properties packagePrefixes = J2objcUtils.packagePrefixes(project, translateArgs)
         List<String> testNames = getTestNames(project, getTestSrcFiles(), packagePrefixes)
 
         ByteArrayOutputStream output = new ByteArrayOutputStream()

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcTranslateTask.groovy
@@ -18,7 +18,6 @@ package com.github.j2objccontrib.j2objcgradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
@@ -56,17 +55,17 @@ class J2objcTranslateTask extends DefaultTask {
     // All input files that could affect translation output, except those in j2objc itself.
     @InputFiles
     FileCollection getAllInputFiles() {
-        FileCollection allFiles = srcFiles
+        FileCollection allFiles = getSrcFiles()
         if (getTranslateSourcepaths()) {
             List<String> translateSourcepathPaths = getTranslateSourcepaths().split(':') as List<String>
             translateSourcepathPaths.each { String sourcePath ->
                 allFiles = allFiles.plus(project.files(sourcePath))
             }
         }
-        generatedSourceDirs.each { String sourceDir ->
+        getGeneratedSourceDirs().each { String sourceDir ->
             allFiles = allFiles.plus(project.files(sourceDir))
         }
-        translateClassPaths.each { String classPath ->
+        getTranslateClassPaths().each { String classPath ->
             allFiles = allFiles.plus(project.files(classPath))
         }
         return allFiles
@@ -220,7 +219,7 @@ class J2objcTranslateTask extends DefaultTask {
 
         // TODO perform file collision check with already translated files in the srcGenDir
         if (getFilenameCollisionCheck()) {
-            J2objcUtils.filenameCollisionCheck(srcFiles)
+            J2objcUtils.filenameCollisionCheck(getSrcFiles())
         }
 
         String classPathArg = J2objcUtils.getClassPathArg(

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
@@ -24,8 +24,6 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 import java.util.regex.Matcher
 
-import java.util.regex.Matcher
-
 /**
  * Internal utilities supporting plugin implementation.
  */
@@ -112,7 +110,7 @@ class J2objcUtils {
     //   --prefixes dir/prefixes.properties --prefix com.ex.dir=Short --prefix com.ex.dir2=Short2
     // TODO: separate this out to a distinct argument that's added to translateArgs
     // TODO: @InputFile conversion for this
-    static Properties prefixProperties(Project proj, List<String> translateArgs) {
+    static Properties packagePrefixes(Project proj, List<String> translateArgs) {
         Properties props = new Properties()
         String joinedTranslateArgs = translateArgs.join(' ')
         Matcher matcher = (joinedTranslateArgs =~ /--prefix(|es)\s+(\S+)/)
@@ -171,7 +169,7 @@ class J2objcUtils {
     // add Java files to a FileCollection
     static FileCollection addJavaFiles(Project proj, FileCollection files, List<String> generatedSourceDirs) {
         if (generatedSourceDirs.size() > 0) {
-            generatedSourceDirs.each { sourceDir ->
+            generatedSourceDirs.each { String sourceDir ->
                 log.debug "include generatedSourceDir: " + sourceDir
                 FileCollection buildSrcFiles = proj.files(proj.fileTree(dir: sourceDir, includes: ["**/*.java"]))
                 files += buildSrcFiles
@@ -197,11 +195,11 @@ class J2objcUtils {
                                List<String> translateJ2objcLibs) {
         String[] classPathList = []
         // user defined libraries
-        libraries.each { library ->
+        libraries.each { String library ->
             classPathList += proj.file(library).absolutePath
         }
         // j2objc default libraries
-        translateJ2objcLibs.each { library ->
+        translateJ2objcLibs.each { String library ->
             classPathList += j2objcHome + "/lib/" + library
         }
         return classPathList.join(':')

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtilsTest.groovy
@@ -64,7 +64,7 @@ public class J2objcUtilsTest {
 
         List<String> translateArgs = new ArrayList<String>()
         translateArgs.add("--prefixes ${prefixesProp.absolutePath}")
-        Properties properties = J2objcUtils.prefixProperties(proj, translateArgs)
+        Properties properties = J2objcUtils.packagePrefixes(proj, translateArgs)
 
         Properties expected = new Properties()
         expected.setProperty('com.example.parent', 'ParentPrefixesFile')
@@ -87,7 +87,7 @@ public class J2objcUtilsTest {
         // prefix overwrites prefixes.properties
         translateArgs.add('--prefix com.example.parent.subdir=SubdirPrefixArg')
 
-        Properties properties = J2objcUtils.prefixProperties(proj, translateArgs)
+        Properties properties = J2objcUtils.packagePrefixes(proj, translateArgs)
 
         Properties expected = new Properties()
         expected.setProperty('com.example.parent', 'ParentPrefixesFile')


### PR DESCRIPTION
Depends on PR #220
- Add explicit types for `->` style iteration, fixes #205
- prefixProperties => packagePrefixes
- srcFiles => getSrcFiles() to make method call explicit
- Other similar cases as above
- ArrayList for {objcCompiler|linker}.withArguments iterators
- Configure: args => List<String> args