### PR TITLE
xcodeProjectDir relative path, fixes #226

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTask.groovy
@@ -16,10 +16,12 @@
 
 package com.github.j2objccontrib.j2objcgradle.tasks
 
+import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
@@ -49,33 +51,29 @@ class J2objcXcodeTask extends DefaultTask {
     File getPodspecFile() { new File(project.buildDir, "${getPodName()}.podspec") }
 
     @OutputFile
-    File getPodFile() { new File(project.j2objcConfig.xcodeProjectDir, "Podfile") }
+    // Cast to string to avoid Groovy throwing exception on ambiguous method call: issue #226
+    File getPodFile() {
+        verifyXcodeArgs()
+        // xcodeProjectDir is relative to projectDir if it's not an absolute path
+        File xcodeProjectDir = project.file(getXcodeProjectDir())
+        new File(xcodeProjectDir, "Podfile")
+    }
 
     // j2objcConfig dependencies for UP-TO-DATE checks
     @Input
     String getJ2ObjCHome() { return J2objcUtils.j2objcHome(project) }
 
-    @Input
+    @Input @Optional
     String getXcodeProjectDir() { return project.j2objcConfig.xcodeProjectDir }
 
-    @Input
+    @Input @Optional
     String getXcodeTarget() { return project.j2objcConfig.xcodeTarget }
 
 
     @TaskAction
-    void pod(IncrementalTaskInputs inputs) {
+    void xcodeConfig(IncrementalTaskInputs inputs) {
 
-        if (getXcodeProjectDir() == null ||
-            getXcodeTarget() == null) {
-            String message =
-                    'Xcode settings needs to be configured, modify in build.gradle:\n' +
-                    '\n' +
-                    'j2objcConfig {\n' +
-                    '    xcodeProjectDir "\${projectDir}/../ios"\n' +
-                    '    xcodeTarget "<TARGET_NAME>"\n' +
-                    '}\n'
-            throw new InvalidUserDataException(message)
-        }
+        verifyXcodeArgs()
 
         // Resource Folder is copied to buildDir where it's accessed by the pod later
         // TODO: is it necessary to copy the files or can they be referenced in place?
@@ -119,11 +117,13 @@ class J2objcXcodeTask extends DefaultTask {
         File podFile = getPodFile()
         if (!podFile.exists()) {
             // TODO: offer to run the setup commands
+            String xcodeAbsPath = project.file(getXcodeProjectDir()).absolutePath
             String message =
-                    "No podfile exists in the directory: ${getXcodeProjectDir()}\n" +
-                    "Create the Podfile in that directory with this command:\n" +
+                    "No podfile exists in the xcodeProjectDir directory:\n" +
+                    "    ${podFile.path}\n" +
                     "\n" +
-                    "(cd ${getXcodeProjectDir()} && pod init)\n" +
+                    "The Podfile needes to be created with this command:\n" +
+                    "    (cd $xcodeAbsPath && pod init)\n" +
                     "\n" +
                     "If the pod command isn't found, then install CocoaPods:\n" +
                     "    sudo gem install cocoapods"
@@ -160,6 +160,21 @@ class J2objcXcodeTask extends DefaultTask {
             }
             logger.debug 'Pod install output:'
             logger.debug output.toString()
+        }
+    }
+
+    @VisibleForTesting
+    void verifyXcodeArgs() {
+        if (getXcodeProjectDir() == null ||
+            getXcodeTarget() == null) {
+            String message =
+                    'Xcode settings need to be configured in this project\'s build.gradle:\n' +
+                    '\n' +
+                    'j2objcConfig {\n' +
+                    '    xcodeProjectDir \'../ios\'\n' +
+                    '    xcodeTarget \'<TARGET_NAME>\'\n' +
+                    '}\n'
+            throw new InvalidUserDataException(message)
         }
     }
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcXcodeTaskTest.groovy
@@ -16,6 +16,8 @@
 
 package com.github.j2objccontrib.j2objcgradle.tasks
 
+import com.github.j2objccontrib.j2objcgradle.J2objcPluginExtension
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Before
@@ -34,6 +36,38 @@ public class J2objcXcodeTaskTest {
     @Before
     void setUp() {
         proj = ProjectBuilder.builder().build()
+    }
+
+    @Test
+    public void getPodFile_Valid() {
+        J2objcPluginExtension j2objcConfig =
+                proj.extensions.create('j2objcConfig', J2objcPluginExtension, proj)
+        j2objcConfig.xcodeProjectDir = '../ios'
+        j2objcConfig.xcodeTarget = 'IosApp'
+
+        // Cast required as return type of create(...) is Task
+        J2objcXcodeTask j2objcXcode =
+                (J2objcXcodeTask) proj.tasks.create(name: 'j2objcXcode', type: J2objcXcodeTask) {}
+        j2objcXcode.verifyXcodeArgs()
+        File podFile = j2objcXcode.getPodFile()
+
+        String expectedPath = proj.file('../ios').absolutePath + '/Podfile'
+        assert expectedPath == podFile.absolutePath
+    }
+
+    // Test that null xcode arguments cause the expected exception
+    @Test(expected = InvalidUserDataException.class)
+    public void getPodFile_Invalid() {
+        J2objcPluginExtension j2objcConfig =
+                proj.extensions.create('j2objcConfig', J2objcPluginExtension, proj)
+        assert j2objcConfig.xcodeProjectDir == null
+        assert j2objcConfig.xcodeTarget == null
+
+        // Cast required as return type of create(...) is Task
+        J2objcXcodeTask j2objcXcode =
+                (J2objcXcodeTask) proj.tasks.create(name: 'j2objcXcode', type: J2objcXcodeTask) {}
+        // Test for fixing issue #226
+        j2objcXcode.getPodFile()
     }
 
     @Test


### PR DESCRIPTION
- (String) cast to clarify ambiguous method call
- Unit tests for the fix (valid and invalid args)
- @Optional for possibly null j2objcConfig members
- Single quote for string
- Allow relative path for xcodeProjectDir
- Reworked error messages to handle relative paths