### PR TITLE
CycleFinder Fix + improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,39 @@ disable the `j2objcTest` task, do the following:
 This task is disabled by default as it requires greater sophistication to use. It runs the
 `cycle_finder` tool in the J2ObjC release to detect memory cycles in your application.
 Objects that are part of a memory cycle on iOS won't be deleted as it doesn't support
-garbage collection. The tool will give you configuration feedback when you use it.
-To enable it:
+garbage collection.
+
+The basic setup will implicitly check for 40 memory cycles - this is the expected number
+of erroneous matches with `jre_emul` library for j2objc version 0.9.6.1. This may cause
+issues if this number changes with new versions of j2objc libraries.
 
     j2objcCycleFinder {
         enabled = true
     }
 
-For more details: http://j2objc.org/docs/Cycle-Finder-Tool.html
+##### Cycle Finder Advanced Setup
+
+This uses a specially annotated version of the `jre_emul` source that marks all the
+erroneously matched cycles such that they can be ignored. It requires downloading
+and building the J2ObjC source:
+
+1. Download the j2objc source to a directory (hereafter J2OJBC_REPO):<br>
+    https://github.com/google/j2objc
+2. Within the J2OJBC_REPO, run:<br>
+    `(cd jre_emul && make java_sources_manifest)`
+3. Configure j2objcConfig in build.gradle so CycleFinder uses the annotated J2ObjC source
+and whitelist. Note how this give expected cycles of zero.
+```
+j2objcConfig {
+    cycleFinderArgs '--whitelist', 'J2OBJC_REPO/jre_emul/cycle_whitelist.txt'
+    cycleFinderArgs '--sourcefilelist', 'J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
+    cycleFinderExpectedCycles 0
+}
+```
+
+For more details:
+- http://j2objc.org/docs/Cycle-Finder-Tool.html
+- https://groups.google.com/forum/#!msg/j2objc-discuss/2fozbf6-liM/R83v7ffX5NMJ
 
 
 ### Plugin Development

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/J2objcUtils.groovy
@@ -20,7 +20,6 @@ import groovy.util.logging.Slf4j
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 import java.util.regex.Matcher
 
@@ -214,16 +213,16 @@ class J2objcUtils {
         Matcher matcher = (str =~ regex)
         if (!matcher.find()) {
             throw new IllegalArgumentException(
-                    "${str}\n" +
+                    "$str\n" +
                     "\n" +
-                    "Regex couldn't match number in output: ${regex}")
+                    "Regex couldn't match number in output: $regex")
         } else {
             String value = matcher[0][1]
             if (!value.isInteger()) {
                 throw new IllegalArgumentException(
-                        "${str}\n" +
+                        "$str\n" +
                         "\n" +
-                        "Regex didn't find number in output: ${regex}, value: ${value}")
+                        "Regex didn't find number in output: $regex, value: $value")
             }
             return value.toInteger()
         }


### PR DESCRIPTION
- Fix cycle_finder!!!
- Was erroneously calling j2objc instead of cycle_finder
- Comment that “40 expected cycles” is for version 0.9.6.1
- Move j2objcCycleFinder instructions to README
- Improved error for expected cycle mismatch
- Strong assert on zero cycles

Other Improvements:
- Remove redundant SourceDirectorySet imports
- “${var}” => “$var” in a few places

TESTED for both regular and difficult modes of Cycle Finder