### PR TITLE
translateSourcepaths to relative paths + refactor

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -84,8 +84,8 @@ class J2objcConfig {
      *
      * @param generatedSourceDirs adds generated source directories for j2objc translate
      */
-    void generatedSourceDirs(String... args) {
-        appendArgs(this.generatedSourceDirs, 'generatedSourceDirs', args)
+    void generatedSourceDirs(String... generatedSourceDirs) {
+        appendArgs(this.generatedSourceDirs, 'generatedSourceDirs', generatedSourceDirs)
     }
 
 
@@ -105,8 +105,8 @@ class J2objcConfig {
      *
      * @param cycleFinderArgs add args for 'cycle_finder' tool
      */
-    void cycleFinderArgs(String... args) {
-        appendArgs(this.cycleFinderArgs, 'cycleFinderArgs', args)
+    void cycleFinderArgs(String... cycleFinderArgs) {
+        appendArgs(this.cycleFinderArgs, 'cycleFinderArgs', cycleFinderArgs)
     }
     /**
      * Expected number of cycles, defaults to all those found in JRE.
@@ -133,23 +133,36 @@ class J2objcConfig {
      *
      * @param translateArgs add args for the 'j2objc' tool
      */
-    void translateArgs(String... args) {
-        appendArgs(this.translateArgs, 'translateArgs', args)
+    void translateArgs(String... translateArgs) {
+        appendArgs(this.translateArgs, 'translateArgs', translateArgs)
     }
 
     /**
-     *  Libraries from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar".
+     *  Local jars for translation e.g.: "lib/json-20140107.jar", "lib/somelib.jar".
      *  This will be added to j2objc as a '-classpath' argument.
      */
-    List<String> translateClassPaths = new ArrayList<>()
+    List<String> translateClasspaths = new ArrayList<>()
     /**
-     *  Add libraries from ${projectDir}/lib/, e.g.: "json-20140107.jar", "somelib.jar".
+     *  Local jars for translation e.g.: "lib/json-20140107.jar", "lib/somelib.jar".
      *  This will be added to j2objc as a '-classpath' argument.
      *
-     *  @param add libraries for -classpath argument
+     *  @param translateClasspaths add libraries for -classpath argument
      */
-    void translateClassPaths(String... args) {
-        appendArgs(this.translateClassPaths, 'translateClassPaths', args)
+    void translateClasspaths(String... translateClasspaths) {
+        appendArgs(this.translateClasspaths, 'translateClasspaths', translateClasspaths)
+    }
+
+    /**
+     * Source jars for translation e.g.: "lib/json-20140107-sources.jar"
+     */
+    List<String> translateSourcepaths = new ArrayList<>()
+    /**
+     * Source jars for translation e.g.: "lib/json-20140107-sources.jar"
+     *
+     *  @param translateSourcepaths args add source jar for translation
+     */
+    void translateSourcepaths(String... translateSourcepaths) {
+        appendArgs(this.translateSourcepaths, 'translateSourcepaths', translateSourcepaths)
     }
 
 
@@ -157,7 +170,7 @@ class J2objcConfig {
     // WARNING: Do not use this unless you know what you are doing.
     // If true, incremental builds will be supported even if --build-closure is included in
     // translateArgs. This may break the build in unexpected ways if you change the dependencies
-    // (e.g. adding new files or changing translateClassPaths). When you change the dependencies and
+    // (e.g. adding new files or changing translateClasspaths). When you change the dependencies and
     // the build breaks, you need to do a clean build.
     boolean UNSAFE_incrementalBuildClosure = false
 
@@ -225,11 +238,6 @@ class J2objcConfig {
     }
 
     /**
-     * Additional sourcepaths to translate.
-     */
-    String translateSourcepaths = null
-
-    /**
      * @see #dependsOnJ2objcLib(org.gradle.api.Project)
      */
     // TODO: Do this automatically based on project dependencies.
@@ -248,7 +256,7 @@ class J2objcConfig {
      * It is safe to use this in conjunction with --build-closure.
      * <p/>
      * Do not also include beforeProject's java source or jar in the
-     * translateSourcepaths or translateClassPaths, respectively.  Calling this method
+     * translateSourcepaths or translateClasspaths, respectively.  Calling this method
      * is preferable and sufficient.
      */
     // TODO: Do this automatically based on project dependencies.
@@ -314,10 +322,10 @@ class J2objcConfig {
     /**
      * Add command line arguments for j2objcTest task.
      *
-     * @param args add args for the 'j2objcTest' task
+     * @param testArgs add args for the 'j2objcTest' task
      */
-    void testArgs(String... args) {
-        appendArgs(this.testArgs, 'testArgs', args)
+    void testArgs(String... testArgs) {
+        appendArgs(this.testArgs, 'testArgs', testArgs)
     }
 
     /**
@@ -374,9 +382,9 @@ class J2objcConfig {
      * Add directories of Objective-C source to compile in addition to the
      * translated source.
      *
-     * @param dirs add directories for Objective-C source to be compiled
+     * @param extraObjcSrcDirs add directories for Objective-C source to be compiled
      */
-    void extraObjcSrcDirs(String... args) {
+    void extraObjcSrcDirs(String... extraObjcSrcDirs) {
         for (String arg in args) {
             extraObjcSrcDirs += arg
         }
@@ -389,9 +397,9 @@ class J2objcConfig {
     /**
      * Add arguments to pass to the native compiler.
      *
-     * @param dirs add arguments to pass to the native compiler.
+     * @param extraObjcCompilerArgs add arguments to pass to the native compiler.
      */
-    void extraObjcCompilerArgs(String... args) {
+    void extraObjcCompilerArgs(String... extraObjcCompilerArgs) {
         for (String arg in args) {
             extraObjcCompilerArgs += arg
         }
@@ -404,9 +412,9 @@ class J2objcConfig {
     /**
      * Add arguments to pass to the native linker.
      *
-     * @param dirs add arguments to pass to the native linker.
+     * @param extraLinkerArgs add arguments to pass to the native linker.
      */
-    void extraLinkerArgs(String... args) {
+    void extraLinkerArgs(String... extraLinkerArgs) {
         for (String arg in args) {
             extraLinkerArgs += arg
         }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTask.groovy
@@ -40,7 +40,7 @@ class TestTask extends DefaultTask {
     FileCollection getTestSrcFiles() {
         // Note that neither testPattern nor translatePattern need to be @Input methods because they are solely
         // inputs to this method, which is already an input via @InputFiles.
-        FileCollection allFiles = Utils.srcDirs(project, 'test', 'java')
+        FileCollection allFiles = Utils.srcSet(project, 'test', 'java')
 
         if (project.j2objcConfig.translatePattern != null) {
             allFiles = allFiles.matching(project.j2objcConfig.translatePattern)

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -81,7 +81,7 @@ class XcodeTask extends DefaultTask {
         String j2objcResourceDirPath = "${project.buildDir}/${j2objcResourceDirName}"
         project.delete j2objcResourceDirPath
         project.copy {
-            Utils.srcDirs(project, 'main', 'resources').srcDirs.each {
+            Utils.srcSet(project, 'main', 'resources').srcDirs.each {
                 from it
             }
             into j2objcResourceDirPath

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
@@ -64,11 +64,11 @@ class CycleFinderTaskTest {
         }
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        mockProjectExec.demandExec(
+        mockProjectExec.demandExecAndReturn(
                 [
                         '/J2OBJC_HOME/cycle_finder',
                         '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
-                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
                 ],
                 'IGNORE\n40 CYCLES FOUND\nIGNORE',
                 null,
@@ -79,7 +79,7 @@ class CycleFinderTaskTest {
         mockProjectExec.verify()
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidUserDataException.class)
     void cycleFinder_Simple_NoFiles_Failure() {
         J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
         assert 40 == j2objcConfig.cycleFinderExpectedCycles
@@ -89,11 +89,11 @@ class CycleFinderTaskTest {
         }
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        mockProjectExec.demandExec(
+        mockProjectExec.demandExecAndReturn(
                 [
                         '/J2OBJC_HOME/cycle_finder',
                         '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
-                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
                 ],
                 // Note the '50' cycles instead of expected 40
                 'IGNORE\n50 CYCLES FOUND\nIGNORE',
@@ -122,11 +122,11 @@ class CycleFinderTaskTest {
         }
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        mockProjectExec.demandExec(
+        mockProjectExec.demandExecAndReturn(
                 [
                         '/J2OBJC_HOME/cycle_finder',
                         '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
-                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
                         '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
                         '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
                 ])
@@ -136,7 +136,7 @@ class CycleFinderTaskTest {
         mockProjectExec.verify()
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidUserDataException.class)
     void cycleFinder_Advanced_NoFiles_Failure() {
         J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
         j2objcConfig.translateArgs('--no-package-directories')
@@ -149,11 +149,11 @@ class CycleFinderTaskTest {
         }
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        mockProjectExec.demandExec(
+        mockProjectExec.demandExecAndReturn(
                 [
                         '/J2OBJC_HOME/cycle_finder',
                         '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
-                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
                         '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
                         '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
                 ],

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
@@ -104,12 +104,12 @@ class MockProjectExec {
         return ( Project ) proxyInstance
     }
 
-    void demandExec(
+    void demandExecAndReturn(
             List<String> expectedCommandLine) {
-        demandExec(expectedCommandLine, null, null, null)
+        demandExecAndReturn(expectedCommandLine, null, null, null)
     }
 
-    void demandExec(
+    void demandExecAndReturn(
             List<String> expectedCommandLine,
             String errorOutputToWrite,
             String standardOutputToWrite,

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
@@ -60,7 +60,7 @@ class TranslateTaskTest {
         }
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        mockProjectExec.demandExec(
+        mockProjectExec.demandExecAndReturn(
                 [
                         '/J2OBJC_HOME/j2objc',
                         '-d', '/PROJECT_DIR/build/j2objcSrcGen',


### PR DESCRIPTION
J2objConfig changes:
- translateSourcepaths to List<String>
- Refactor translateSourcepaths, translateClasspaths & generatedSourceDirs
- SourcePath => sourcepath, ClassPath => classpath
- Fully name parameters

Task changes:
- Remove @Optional from List<String> @Inputs (always defined)
- Reorder @Inputs for consistency
- Remove advanced CycleFinder setup instructions

Rename:
- Utils.srcDirs => srcSet, indicates a set of files
- Remove Utils.sourcepathJava and inline calls to getSrcDirs()
  (it was confusing returning sets of files and directories)

Testing:
- Added testJ2objcHome
- Added testSrcSet
- Added testThrowIfNoJavaPlugin_JavaPlugin