### PR TITLE
Move errors to FAQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,42 +36,42 @@ Further Customizations:
 
 * Function calls should use parentheses:
 ```
-logging.captureStandardOutput(LogLevel.INFO)  // approved
-logging.captureStandardOutput LogLevel.INFO   // avoid
+logging.captureStandardOutput(LogLevel.INFO)  // CORRECT
+logging.captureStandardOutput LogLevel.INFO   // WRONG
 ```
 * Configure calls do not use parentheses:
 ```
 project.exec {
-    executable 'j2objc'              // approved
-    args '-sourcepath', sourcepath   // approved
+    executable 'j2objc'              // CORRECT
+    args '-sourcepath', sourcepath   // CORRECT
 
-    executable('j2objc')             // avoid
-    args('-sourcepath', sourcepath)  // avoid
+    executable('j2objc')             // WRONG
+    args('-sourcepath', sourcepath)  // WRONG
 }
 ```
 * Explicit Types instead of 'def':
 ```
-String message = 'a message'  // approved
-def message = 'a message'     // avoid
+String message = 'a message'  // CORRECT
+def message = 'a message'     // WRONG
 
 // This also applies for '->' iterators:
-translateArgs.each { String arg ->  // approved
-translateArgs.each { arg ->         // avoid
+translateArgs.each { String arg ->  // CORRECT
+translateArgs.each { arg ->         // WRONG
 ```
 * GString curly braces only for methods or object members:
 ```
-String message = "the count is $count"           // approved
-String message = "the count is ${object.count}"  // approved
-String message = "the count is ${method()}"      // approved
+String message = "the count is $count"           // CORRECT
+String message = "the count is ${object.count}"  // CORRECT
+String message = "the count is ${method()}"      // CORRECT
 
-String message = "the count is ${count}"         // avoid
-String message = "the count is $method()"        // avoid
+String message = "the count is ${count}"         // WRONG
+String message = "the count is $method()"        // WRONG
 String message = "the count is $object.count"    // incorrect as it only prints "$object"
 ```
 * Single quotes for non-GString, i.e. no string interpolation:
 ```
-String message = 'the count is negative'  // approved
-String message = "the count is negative"  // avoid - only needed for $var interpolation
+String message = 'the count is negative'  // CORRECT
+String message = "the count is negative"  // WRONG - only needed for $var interpolation
 ```
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,15 +1,18 @@
 # FAQ
 (for contributors, see [CONTRIBUTING.md](CONTRIBUTING.md))
 
+
 ### What version of Gradle do I need?
 
 You need at least [Gradle version 2.4](https://discuss.gradle.org/t/gradle-2-4-released/9471),
 due to support for native compilation features.
 
+
 ### How do I solve the Eclipse error message ``Obtaining Gradle model...``?
 
 You have to first create the [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 Go to your project folder and do ``gradle wrapper``. Refresh your Eclipse project.
+
 
 ### How do I properly pass multiple arguments to j2objc?
 
@@ -58,9 +61,21 @@ Add the following to your configuration block. [See](https://developer.apple.com
 ```
 j2objcConfig {
    translateArgs '-use-arc'
-   extraObjcCompilerArgs += '-fobjc-arc'
+   extraObjcCompilerArgs '-fobjc-arc'
 }
 ```
+
+### How do I call finalConfigure()?
+
+You must always call finalConfigure at the end of `j2objcConfig {...}` within your project's
+`build.gradle` file. You need to include an otherwise empty j2objcConfig { } block with this
+call even if you do not need to customize any other `j2objConfig` option.
+
+    j2objcConfig {
+        ...
+        finalConfigure()
+    }
+
 
 ### Error: implicit declaration of function 'JreRelease' is invalid in C99 [-Werror,-Wimplicit-function-declaration] JreRelease(this$0_)
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -51,28 +51,16 @@ class J2objcPlugin implements Plugin<Project> {
                 Utils.throwIfNoJavaPlugin(evaluatedProject)
 
                 if (!evaluatedProject.j2objcConfig.isFinalConfigured()) {
-                    String message = "You must call finalConfigure() in j2objcConfig, ex:\n" +
-                                  "j2objcConfig {\n" +
-                                  "    // other settings\n" +
-                                  "    finalConfigure()\n" +
-                                  "}"
-                    throw new InvalidUserDataException(message)
+                    logger.error "Project '${evaluatedProject.name}' is missing finalConfigure():\n" +
+                                 "https://github.com/j2objc-contrib/j2objc-gradle/blob/master/FAQ.md#How-do-I-call-finalConfigure"
                 }
 
                 boolean arcTranslateArg = '-use-arc' in evaluatedProject.j2objcConfig.translateArgs
                 boolean arcCompilerArg = '-fobjc-arc' in evaluatedProject.j2objcConfig.extraObjcCompilerArgs
                 if (arcTranslateArg && !arcCompilerArg || !arcTranslateArg && arcCompilerArg) {
-                    logger.error "${evaluatedProject.name}: using ARC with J2ObjC, the project is missing one of the two arguments required:\n" +
-                        "\n" +
-                        "j2objcConfig {\n" +
-                        "    // other settings\n" +
-                        "    translateArgs '-use-arc'\n" +
-                        // TODO: extraObjcCompilerArgs '-fobjc-arc'
-                        "    extraObjcCompilerArgs = ['-fobjc-arc']\n" +
-                        "}\n" +
-                        "-fobjc-arc enables Automatic Reference Counting functionality in the compiler:\n" +
-                        "https://developer.apple.com/library/mac/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW15"
-                } 
+                    logger.error "Project '${evaluatedProject.name}' is missing required ARC flags:\n" +
+                                 "https://github.com/j2objc-contrib/j2objc-gradle/blob/master/FAQ.md#how-do-i-enable-arc-for-my-objective-c-classes"
+                }
             }
 
             // This is an intermediate directory only.  Clients should use only directories


### PR DESCRIPTION
- Move ARC and finalConfigure errors to FAQ
- Standardize style guideline wording on ‘CORRECT’ and ‘WRONG’