### PR TITLE
CycleFinderTask and TranslateTask Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ These are the main tasks for the plugin:
     j2objcXcode             - Configure Xcode to link to static library and header files
 
 Note that you can use the Gradle shorthand of "$ gradlew jA" to do the j2objcAssemble task.
-The other shorthand expressions are `jC`, `jTr`, `jA`, `jTe` and `jX`.
+The other shorthand expressions are `jCF`, `jTr`, `jA`, `jTe` and `jX`.
 
 
 #### Task Enable and Disable

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -42,7 +42,6 @@ class Utils {
             String message =
                     "j2objc plugin didn't find the 'java' plugin in the '${proj.name}' project.\n" +
                     "This is a requirement for using j2objc. Please see usage information at:\n" +
-                    "\n" +
                     "https://github.com/j2objc-contrib/j2objc-gradle/#usage"
             throw new InvalidUserDataException(message)
         }
@@ -70,8 +69,8 @@ class Utils {
         return javaRoots.join(':')
     }
 
-    // MUST be used only in @Input getJ2ObjCHome() methods to ensure UP-TO-DATE checks are correct
-    // @Input getJ2ObjCHome() method can be used freely inside the task action
+    // MUST be used only in @Input getJ2objcHome() methods to ensure UP-TO-DATE checks are correct
+    // @Input getJ2objcHome() method can be used freely inside the task action
     static String j2objcHome(Project proj) {
         File localPropertiesFile = new File(proj.rootDir, 'local.properties')
         String result = null
@@ -213,16 +212,16 @@ class Utils {
         Matcher matcher = (str =~ regex)
         if (!matcher.find()) {
             throw new IllegalArgumentException(
+                    "Content:\n" +
                     "$str\n" +
-                    "\n" +
-                    "Regex couldn't match number in output: $regex")
+                    "Regex couldn't match number: $regex")
         } else {
             String value = matcher[0][1]
             if (!value.isInteger()) {
                 throw new IllegalArgumentException(
+                        "Content:\n" +
                         "$str\n" +
-                        "\n" +
-                        "Regex didn't find number in output: $regex, value: $value")
+                        "Regex couldn't match number: $regex")
             }
             return value.toInteger()
         }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -61,7 +61,7 @@ class XcodeTask extends DefaultTask {
 
     // j2objcConfig dependencies for UP-TO-DATE checks
     @Input
-    String getJ2ObjCHome() { return Utils.j2objcHome(project) }
+    String getJ2objcHome() { return Utils.j2objcHome(project) }
 
     @Input @Optional
     String getXcodeProjectDir() { return project.j2objcConfig.xcodeProjectDir }
@@ -106,8 +106,8 @@ class XcodeTask extends DefaultTask {
                 "s.requires_arc = true\n" +
                 "s.preserve_paths = '${srcGenDirRelativeToBuildDir}**/*.a'\n" +
                 "s.libraries = 'ObjC', 'guava', 'javax_inject', 'jre_emul', 'jsr305', 'z', 'icucore', '${project.name}-j2objc'\n" +
-                "s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${getJ2ObjCHome()}/include', " +
-                "'LIBRARY_SEARCH_PATHS' => '${getJ2ObjCHome()}/lib ${project.buildDir}/j2objcOutputs/lib/iosDebug' }\n" +
+                "s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${getJ2objcHome()}/include', " +
+                "'LIBRARY_SEARCH_PATHS' => '${getJ2objcHome()}/lib ${project.buildDir}/j2objcOutputs/lib/iosDebug' }\n" +
                 "end\n"
         logger.debug 'podspecFileContents creation...\n\n' + podspecFileContents
         File podspecFile = getPodspecFile()

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle.tasks
+
+import com.github.j2objccontrib.j2objcgradle.J2objcConfig
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.process.internal.ExecException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * CycleFinderTask tests.
+ */
+public class CycleFinderTaskTest {
+
+    private Project proj
+    private String j2objcHome
+
+    @Before
+    void setUp() {
+        proj = ProjectBuilder.builder().build()
+
+        // For Utils.throwIfNoJavaPlugin()
+        proj.pluginManager.apply(JavaPlugin)
+
+        // For Utils.J2objcHome()
+        j2objcHome = File.createTempDir('J2OBJC_HOME', '').path
+        File localProperties = proj.file('local.properties')
+        localProperties.write("j2objc.home=$j2objcHome\n")
+
+        // For reportFile
+        proj.getBuildDir().mkdir()
+        File reportDir = new File("${proj.buildDir}/reports")
+        reportDir.mkdir()
+    }
+
+    // TODO: add java source files to the test cases
+    // TODO: perhaps even better, point the project towards an existing example
+
+    @Test
+    public void cycleFinderWithExec_SimpleModeSuccess() {
+
+        J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
+        assert 40 == j2objcConfig.cycleFinderExpectedCycles
+
+        CycleFinderTask j2objcCycleFinder = (CycleFinderTask) proj.tasks.create(
+                name: 'j2objcCycleFinder', type: CycleFinderTask) {
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExec(
+                [
+                        '/J2OBJC_HOME/cycle_finder',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                ],
+                'IGNORE\n40 CYCLES FOUND\nIGNORE',
+                null,
+                new ExecException('Non-Zero Exit'))
+
+        j2objcCycleFinder.cycleFinderWithExec(mockProjectExec.projectProxyInstance())
+
+        mockProjectExec.verify()
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cycleFinderWithExec_SimpleModeFailure() {
+
+        J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
+        assert 40 == j2objcConfig.cycleFinderExpectedCycles
+
+        CycleFinderTask j2objcCycleFinder = (CycleFinderTask) proj.tasks.create(
+                name: 'j2objcCycleFinder', type: CycleFinderTask) {
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExec(
+                [
+                        '/J2OBJC_HOME/cycle_finder',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                ],
+                // Note the '50' cycles instead of expected 45
+                'IGNORE\n50 CYCLES FOUND\nIGNORE',
+                null,
+                new ExecException('Non-Zero Exit'))
+
+        j2objcCycleFinder.cycleFinderWithExec(mockProjectExec.projectProxyInstance())
+
+        mockProjectExec.verify()
+    }
+
+    @Test
+    public void cycleFinderWithExec_AdvancedModeSuccess() {
+
+        J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
+        j2objcConfig.translateArgs('--no-package-directories')
+        j2objcConfig.cycleFinderExpectedCycles = 0
+        j2objcConfig.cycleFinderArgs('--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt')
+        j2objcConfig.cycleFinderArgs('--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf')
+
+        CycleFinderTask j2objcCycleFinder = (CycleFinderTask) proj.tasks.create(
+                name: 'j2objcCycleFinder', type: CycleFinderTask) {
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExec(
+                [
+                        '/J2OBJC_HOME/cycle_finder',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
+                        '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
+                ])
+
+        j2objcCycleFinder.cycleFinderWithExec(mockProjectExec.projectProxyInstance())
+
+        mockProjectExec.verify()
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cycleFinderWithExec_AdvancedModeFailure() {
+
+        J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
+        j2objcConfig.translateArgs('--no-package-directories')
+        j2objcConfig.cycleFinderExpectedCycles = 0
+        j2objcConfig.cycleFinderArgs('--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt')
+        j2objcConfig.cycleFinderArgs('--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf')
+
+        CycleFinderTask j2objcCycleFinder = (CycleFinderTask) proj.tasks.create(
+                name: 'j2objcCycleFinder', type: CycleFinderTask) {
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExec(
+                [
+                        '/J2OBJC_HOME/cycle_finder',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar',
+                        '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
+                        '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
+                ],
+                'IGNORE\n2 CYCLES FOUND\nIGNORE',
+                null,
+                new ExecException('Non-Zero Exit'))
+
+        j2objcCycleFinder.cycleFinderWithExec(mockProjectExec.projectProxyInstance())
+
+        mockProjectExec.verify()
+    }
+}

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle.tasks
+
+import groovy.mock.interceptor.MockFor
+import org.gradle.api.Project
+import org.gradle.util.ConfigureUtil
+
+/**
+ * Used for mocking on the project.exec {...} command used by many of the plugin tasks.
+ *
+ * It operates in the following manner:
+ * 1) Allows dependency injection and interception of the project.exec {...} command
+ * 2) Verifies the executable and args compared to expected values
+ * 3) Write to stdout and stderr as specified
+ * 4) Throws an error, e.g. for non-zero exits from the command
+ */
+public class MockProjectExec {
+
+    private Project project
+    private String j2objcHome
+    private static final String j2objcHomeStd = '/J2OBJC_HOME'
+    private static final String projectDirStd = '/PROJECT_DIR'
+
+    private MockFor mockForProj = new MockFor(Project)
+    private MockExec mockExec = new MockExec()
+    private GroovyObject proxyInstance
+
+    MockProjectExec(Project project, String j2objcHome) {
+        this.project = project
+        this.j2objcHome = j2objcHome
+    }
+
+    Project projectProxyInstance() {
+        proxyInstance = mockForProj.proxyInstance()
+        return ( Project ) proxyInstance
+    }
+
+    void demandExec(
+            List<String> expectedCommandLine) {
+        demandExec(expectedCommandLine, null, null, null)
+    }
+
+    void demandExec(
+            List<String> expectedCommandLine,
+            String errorOutputToWrite,
+            String standardOutputToWrite,
+            Exception exceptionToThrow) {
+
+        mockForProj.demand.exec { Closure closure ->
+
+            ConfigureUtil.configure(closure, mockExec)
+
+            assert expectedCommandLine[0] == mockExec.executable.replace(j2objcHome, j2objcHomeStd)
+            expectedCommandLine.remove(0)
+
+            List<String> canonicalizedArgs = mockExec.args.collect { String arg ->
+                return arg
+                        .replace(j2objcHome, j2objcHomeStd)
+                        .replace(project.projectDir.path, projectDirStd)
+            }
+            assert expectedCommandLine == canonicalizedArgs
+
+            if (errorOutputToWrite) {
+                mockExec.errorOutput.write(errorOutputToWrite.getBytes('utf-8'))
+                mockExec.errorOutput.flush()
+            }
+            if (standardOutputToWrite) {
+                mockExec.standardOutput.write(standardOutputToWrite.getBytes('utf-8'))
+                mockExec.standardOutput.flush()
+            }
+
+            if (exceptionToThrow != null) {
+                throw exceptionToThrow
+            }
+        }
+    }
+
+    void verify() {
+        mockForProj.verify(proxyInstance)
+    }
+
+    // Basically mocks Gradle's AbstractExecTask
+    private class MockExec {
+        String executable
+        List<String> args = new ArrayList<>()
+        OutputStream errorOutput;
+        OutputStream standardOutput;
+
+        public void executable(Object executable) {
+            this.executable = (String) executable
+        }
+
+        public void args(Object... args) {
+            args.each { Object arg ->
+                String newArgStr = (String) arg
+                this.args.add(newArgStr)
+            }
+        }
+
+        public void errorOutput(OutputStream errorOutput) {
+            this.errorOutput = errorOutput
+        }
+
+        public void standardOutput(OutputStream standardOutput) {
+            this.standardOutput = standardOutput
+        }
+
+        public String toString() {
+            return executable + ' ' + args.join(' ')
+        }
+    }
+}

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle.tasks
+
+import com.github.j2objccontrib.j2objcgradle.J2objcConfig
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import org.gradle.api.tasks.incremental.InputFileDetails
+import org.gradle.process.internal.ExecException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * TestTask tests.
+ */
+public class TranslateTaskTest {
+
+    private Project proj
+    private String j2objcHome
+
+    @Before
+    void setUp() {
+        proj = ProjectBuilder.builder().build()
+
+        // For Utils.throwIfNoJavaPlugin()
+        proj.pluginManager.apply(JavaPlugin)
+
+        // For Utils.J2objcHome()
+        j2objcHome = File.createTempDir('J2OBJC_HOME', '').path
+        File localProperties = proj.file('local.properties')
+        localProperties.write("j2objc.home=$j2objcHome\n")
+    }
+
+    // TODO: add java source files to the test cases
+    // TODO: perhaps even better, point the project towards an existing example
+
+    @Test
+    public void translateWithExec_BasicArguments() {
+
+        J2objcConfig j2objcConfig = proj.extensions.create('j2objcConfig', J2objcConfig, proj)
+
+        TranslateTask j2objcTranslate = (TranslateTask) proj.tasks.create(
+                name: 'j2objcTranslate', type: TranslateTask) {
+            srcGenDir = proj.file("${proj.buildDir}/j2objcSrcGen")
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExec(
+                [
+                        '/J2OBJC_HOME/j2objc',
+                        '-d', '/PROJECT_DIR/build/j2objcSrcGen',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes'
+                ])
+
+        IncrementalTaskInputs incrementalTaskInputs = new IncrementalTaskInputs() {
+            @Override
+            boolean isIncremental() {
+                return false
+            }
+
+            @Override
+            void outOfDate(Action<? super InputFileDetails> outOfDateAction) {
+            }
+
+            @Override
+            void removed(Action<? super InputFileDetails> removedAction) {
+            }
+        }
+
+        j2objcTranslate.translateWithExec(mockProjectExec.projectProxyInstance(), incrementalTaskInputs)
+
+        mockProjectExec.verify()
+    }
+
+}


### PR DESCRIPTION
Testing Improvements:
- Dependency injection for Project.exec {…} method
- MockProjectExec testing utility class
- First use of the Groovy MockFor system
- CycleFinderTaskTest good coverage
- TranslateTaskTest only basic coverage

Other Changes:
- exec args to have proper iteration for adding as args
- J2objcHome() standardize capitalization