### PR TITLE
Allow j2objc built libraries to link to other Gradle native libraries.

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -420,6 +420,23 @@ class J2objcConfig {
         }
     }
 
+    /**
+     * Additional native libraries to link to.
+     */
+    List<Map> extraNativeLibs = []
+    /**
+     * Add additional native library to link to.
+     * <p/>
+     * For example, if you built native library 'utils' in project 'common':
+     * <pre>
+     * extraNativeLib project: 'common', library: 'utils', linkage: 'static'
+     * </pre>
+     */
+    void extraNativeLib(Map spec) {
+        extraNativeLibs.add(spec)
+    }
+
+
     // XCODE
     /**
      * Directory of the target Xcode project.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
@@ -239,6 +239,9 @@ class NativeCompilation {
                             beforeProjects.each { Project beforeProject ->
                                 lib project: beforeProject.path, library: "${beforeProject.name}-j2objc", linkage: 'static'
                             }
+                            j2objcConfig.extraNativeLibs.each { Map nativeLibSpec ->
+                                lib nativeLibSpec
+                            }
                         }
                     }
 
@@ -258,6 +261,9 @@ class NativeCompilation {
                             // Resolve dependencies from all java j2objc projects using the compiled static libs.
                             beforeProjects.each { Project beforeProject ->
                                 lib project: beforeProject.path, library: "${beforeProject.name}-j2objc", linkage: 'static'
+                            }
+                            j2objcConfig.extraNativeLibs.each { Map nativeLibSpec ->
+                                lib nativeLibSpec
                             }
 
                             // J2ObjC provided libraries for testing only


### PR DESCRIPTION
Note the other libraries could be C[++], Objective-C[++], etc.