### PR TITLE
Fully split debug and release builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ disable the `j2objcTest` task, do the following:
         ...
     }
 
+If you are developing in a tight modify-compile-test loop and using only debug binaries, you
+may want to disable the release build temporarily by adding to your `local.properties` file:
+
+    j2objc.releaseEnabled=false
+
+This should cut the j2objc build time up to 50%.  You can also do this for `j2objc.debugEnabled`.
 
 #### j2objcCycleFinder
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -387,8 +387,8 @@ class J2objcConfig {
      * @param extraObjcSrcDirs add directories for Objective-C source to be compiled
      */
     void extraObjcSrcDirs(String... extraObjcSrcDirs) {
-        for (String arg in args) {
-            extraObjcSrcDirs += arg
+        for (String arg in extraObjcSrcDirs) {
+            this.extraObjcSrcDirs += arg
         }
     }
     /**
@@ -402,8 +402,8 @@ class J2objcConfig {
      * @param extraObjcCompilerArgs add arguments to pass to the native compiler.
      */
     void extraObjcCompilerArgs(String... extraObjcCompilerArgs) {
-        for (String arg in args) {
-            extraObjcCompilerArgs += arg
+        for (String arg in extraObjcCompilerArgs) {
+            this.extraObjcCompilerArgs += arg
         }
     }
     /**
@@ -417,8 +417,8 @@ class J2objcConfig {
      * @param extraLinkerArgs add arguments to pass to the native linker.
      */
     void extraLinkerArgs(String... extraLinkerArgs) {
-        for (String arg in args) {
-            extraLinkerArgs += arg
+        for (String arg in extraLinkerArgs) {
+            this.extraLinkerArgs += arg
         }
     }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015 the authors of j2objc-gradle (see AUTHORS file)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.j2objccontrib.j2objcgradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Assemble task copies generated libraries to assembly directories for
+ * use by an iOS application.
+ */
+class AssembleLibrariesTask extends DefaultTask {
+    // Generated ObjC binaries
+    @InputDirectory
+    File libDir
+
+    @InputDirectory
+    File packedLibDir
+
+    @OutputDirectory
+    File getDestLibDir() {
+        return project.file(getDestLibDirPath())
+    }
+
+    @Input
+    // Debug or Release
+    String buildType
+
+    // j2objcConfig dependencies for UP-TO-DATE checks
+
+    // We keep these strings as @Input properties in addition to the @OutputDirectory methods above because,
+    // for example, whether or not the main source and test source are identical affects execution of this task.
+    @Input
+    String getDestLibDirPath() { return project.j2objcConfig.destLibDir }
+
+    @TaskAction
+    void destCopy() {
+        // We don't need to clear out the library path, our libraries can co-exist
+        // with other libraries if the user wishes them to.
+        project.copy {
+            includeEmptyDirs = true
+            from libDir
+            from packedLibDir
+            into destLibDir
+            include "*$buildType/*.a"
+        }
+    }
+}

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleSourceTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleSourceTask.groovy
@@ -18,28 +18,21 @@ package com.github.j2objccontrib.j2objcgradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.file.ConfigurableFileCollection
 
 /**
- * Assemble task copies generated source and libaries to assembly directories for
+ * Assemble task copies generated source to assembly directories for
  * use by an iOS application.
  */
-class AssembleTask extends DefaultTask {
+class AssembleSourceTask extends DefaultTask {
 
     // Generated ObjC source files
     @InputDirectory
     File srcGenDir
-
-    // Generated ObjC binaries
-    @InputDirectory
-    File libDir
-
-    @InputDirectory
-    File packedLibDir
 
     @OutputDirectory
     File getDestSrcDir() {
@@ -51,11 +44,6 @@ class AssembleTask extends DefaultTask {
         return project.file(destSrcDirTestPath)
     }
 
-    @OutputDirectory
-    File getDestLibDir() {
-        return project.file(destLibDirPath)
-    }
-
     // j2objcConfig dependencies for UP-TO-DATE checks
 
     // We keep these strings as @Input properties in addition to the @OutputDirectory methods above because,
@@ -65,9 +53,6 @@ class AssembleTask extends DefaultTask {
 
     @Input
     String getDestSrcDirTestPath() { return project.j2objcConfig.destSrcDirTest }
-
-    @Input
-    String getDestLibDirPath() { return project.j2objcConfig.destLibDir }
 
 
     private void clearDestSrcDirWithChecks(File destDir, String name) {
@@ -116,16 +101,6 @@ class AssembleTask extends DefaultTask {
             // Only copy the test code
             include "**/*Test.h"
             include "**/*Test.m"
-        }
-
-        // We don't need to clear out the library path, our libraries can co-exist
-        // with other libraries if the user wishes them to.
-        project.copy {
-            includeEmptyDirs = true
-            from libDir
-            from packedLibDir
-            into destLibDir
-            include "**/*.a"
         }
     }
 }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
@@ -35,8 +35,7 @@ class CycleFinderTask extends DefaultTask {
     FileCollection getSrcFiles() {
         // Note that translatePattern does not need to be an @Input because it is
         // solely an input to this method, which is already an input (via @InputFiles).
-        FileCollection allFiles = project.files()
-        allFiles += Utils.srcSet(project, 'main', 'java')
+        FileCollection allFiles = Utils.srcSet(project, 'main', 'java')
         allFiles += Utils.srcSet(project, 'test', 'java')
         if (project.j2objcConfig.translatePattern != null) {
             allFiles = allFiles.matching(project.j2objcConfig.translatePattern)

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -41,8 +41,7 @@ class TranslateTask extends DefaultTask {
         // Note that neither additionalSrcFiles nor translatePattern need
         // to be @Inputs because they are solely inputs to this method, which
         // is already an input.
-        FileCollection allFiles = project.files()
-        allFiles += Utils.srcSet(project, 'main', 'java')
+        FileCollection allFiles = Utils.srcSet(project, 'main', 'java')
         allFiles += Utils.srcSet(project, 'test', 'java')
         if (project.j2objcConfig.translatePattern != null) {
             allFiles = allFiles.matching(project.j2objcConfig.translatePattern)

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -48,18 +48,23 @@ class Utils {
         }
     }
 
-    // MUST be used only in @Input getJ2objcHome() methods to ensure UP-TO-DATE checks are correct
-    // @Input getJ2objcHome() method can be used freely inside the task action
-    static String j2objcHome(Project proj) {
+    static String getLocalProperty(Project proj, String key, String defaultValue = null) {
         File localPropertiesFile = new File(proj.rootDir, 'local.properties')
-        String result = null
+        String result = defaultValue
         if (localPropertiesFile.exists()) {
             Properties localProperties = new Properties();
             localPropertiesFile.withInputStream {
                 localProperties.load it
             }
-            result = localProperties.getProperty('j2objc.home')
+            result = localProperties.getProperty('j2objc.' + key, defaultValue)
         }
+        return result
+    }
+
+    // MUST be used only in @Input getJ2objcHome() methods to ensure UP-TO-DATE checks are correct
+    // @Input getJ2objcHome() method can be used freely inside the task action
+    static String j2objcHome(Project proj) {
+        String result = getLocalProperty(proj, 'home')
         if (result == null) {
             result = System.getenv('J2OBJC_HOME')
         }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -57,6 +57,39 @@ class UtilsTest {
     }
 
     @Test
+    public void testGetLocalProperty_FileNotPresent() {
+        String value = Utils.getLocalProperty(proj, 'debug.enabled')
+        assert value == null
+
+        value = Utils.getLocalProperty(proj, 'debug.enabled', 'true')
+        assert value == 'true'
+    }
+
+    @Test
+    public void testGetLocalProperty_KeyNotPresent() {
+        File localProperties = proj.file('local.properties')
+        localProperties.write('j2objc.release.enabled=false\n')
+
+        String value = Utils.getLocalProperty(proj, 'debug.enabled')
+        assert value == null
+
+        value = Utils.getLocalProperty(proj, 'debug.enabled', 'false')
+        assert value == 'false'
+    }
+
+    @Test
+    public void testGetLocalProperty_KeyPresent() {
+        File localProperties = proj.file('local.properties')
+        localProperties.write('j2objc.debug.enabled=false\n')
+
+        String value = Utils.getLocalProperty(proj, 'debug.enabled')
+        assert value == 'false'
+
+        value = Utils.getLocalProperty(proj, 'debug.enabled', 'true')
+        assert value == 'false'
+    }
+
+    @Test
     public void testJ2objcHome_LocalProperties() {
         // Write j2objc path to local.properties file within the project
         String j2objcHomeWritten = File.createTempDir('J2OBJC_HOME', '').path


### PR DESCRIPTION
Do #271 first please.

```
- Use local.properties: j2objc.debugEnabled=false and j2objc.releaseEnabled=false to globally control
- Both flavors are enabled by default unless explicitly disabled
- j2objcTestDebug and j2objcTestRelease test debug & release binaries.
- j2objcAssembleDebug and j2objcAssembleRelease copy debug & release libraries.  Both copy generated source.
- native compiles also enabled/disabled as needed.
- markers j2objcTest, j2objcAssemble, and j2objcBuild remain and do both debug & release.
```