### PR TITLE
Switch to @CompileStatic in most production code

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
@@ -16,6 +16,9 @@
 
 package com.github.j2objccontrib.j2objcgradle.tasks
 
+import com.github.j2objccontrib.j2objcgradle.J2objcConfig
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -26,6 +29,7 @@ import org.gradle.api.tasks.TaskAction
  * Assemble task copies generated libraries to assembly directories for
  * use by an iOS application.
  */
+@CompileStatic
 class AssembleLibrariesTask extends DefaultTask {
     // Generated ObjC binaries
     @InputDirectory
@@ -48,8 +52,11 @@ class AssembleLibrariesTask extends DefaultTask {
     // We keep these strings as @Input properties in addition to the @OutputDirectory methods above because,
     // for example, whether or not the main source and test source are identical affects execution of this task.
     @Input
-    String getDestLibDirPath() { return project.j2objcConfig.destLibDir }
+    String getDestLibDirPath() { return J2objcConfig.from(project).destLibDir }
 
+    // project.copy closure configuration cannot be replaced with a non-internal
+    // statically compiled alternative.
+    @CompileStatic(TypeCheckingMode.SKIP)
     @TaskAction
     void destCopy() {
         // We don't need to clear out the library path, our libraries can co-exist

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -15,21 +15,23 @@
  */
 
 package com.github.j2objccontrib.j2objcgradle.tasks
-
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
-import java.util.regex.Matcher
 
+import java.util.regex.Matcher
 /**
  * Internal utilities supporting plugin implementation.
  */
 // Without access to the project, logging is performed using the
 // static 'log' variable added during decoration with this annotation.
 @Slf4j
+@CompileStatic
 class Utils {
     // TODO: ideally bundle j2objc binaries with plugin jar and load at runtime with
     // TODO: ClassLoader.getResourceAsStream(), extract, chmod and then execute
@@ -155,9 +157,10 @@ class Utils {
 
         assert fileType == 'java' || fileType == 'resources'
         assert sourceSetName == 'main' || sourceSetName == 'test'
-        SourceSet sourceSet = proj.sourceSets.findByName(sourceSetName)
+        JavaPluginConvention javaConvention = proj.getConvention().getPlugin(JavaPluginConvention);
+        SourceSet sourceSet = javaConvention.sourceSets.findByName(sourceSetName)
         // For standard fileTypes 'java' and 'resources,' per contract this cannot be null.
-        SourceDirectorySet srcDirSet = sourceSet.getProperty(fileType)
+        SourceDirectorySet srcDirSet = fileType == 'java' ? sourceSet.java : sourceSet.resources
         return srcDirSet
     }
 
@@ -201,7 +204,7 @@ class Utils {
                     "$str\n" +
                     "Regex couldn't match number in output: $regex")
         } else {
-            String value = matcher[0][1]
+            String value = matcher.group(1)
             if (!value.isInteger()) {
                 throw new InvalidUserDataException(
                         "Content:\n" +


### PR DESCRIPTION
- Found lots of issues with our (mis)use of FileCollection-ish
- Keeps project.exec and project.copy in dynamically typed extracted methods
- Does not touch the J2objcPlugin or NativeCompilation, which would become
  very unreadable or require use of internal classes for conversion.

Fixes #283 

Do #284 first please.
Unit tests pass.  My projects internally seem to build...