### PR TITLE
projectExec regex match for unexpected output

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
@@ -66,7 +66,7 @@ class PackLibrariesTask extends DefaultTask {
         logger.debug("PackLibrariesTask - projectExec - $name:")
 
         try {
-            Utils.projectExec(project, stdout, stderr, {
+            Utils.projectExec(project, stdout, stderr, null, {
                 executable 'xcrun'
 
                 args 'lipo'
@@ -81,7 +81,7 @@ class PackLibrariesTask extends DefaultTask {
             })
 
         } catch (Exception exception) {
-            // TODO: match on common failure and provide useful help
+            // TODO: match on common failures and provide useful help
             throw exception
         }
     }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -235,7 +235,7 @@ class TranslateTask extends DefaultTask {
 
         logger.debug('TranslateTask - projectExec:')
         try {
-            Utils.projectExec(project, stdout, stderr, {
+            Utils.projectExec(project, stdout, stderr, null, {
                 executable j2objcExecutable
                 windowsOnlyArgs.each { String windowsOnlyArg ->
                     args windowsOnlyArg
@@ -259,7 +259,7 @@ class TranslateTask extends DefaultTask {
             })
 
         } catch(Exception exception) {
-            // TODO: match on common failure and provide useful help
+            // TODO: match on common failures and provide useful help
             throw exception
         }
     }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -140,7 +140,7 @@ class XcodeTask extends DefaultTask {
             ByteArrayOutputStream stderr = new ByteArrayOutputStream()
             try {
                 logger.debug('XcodeTask - projectExec - pod install:')
-                Utils.projectExec(project, stdout, stderr, {
+                Utils.projectExec(project, stdout, stderr, null, {
                     workingDir getXcodeProjectDir()
                     executable 'pod'
                     args 'install'

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
@@ -144,7 +144,7 @@ class TestTaskTest {
                         "${proj.buildDir}/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
-                'OK (2 testXXXX)',  // NOTE: invalid stdout fails matchRegexOutputStreams
+                'OK (2 testXXXX)',  // NOTE: invalid stdout fails matchRegexOutputs
                 '',  // stderr
                 null)
 


### PR DESCRIPTION
If the command line succeeds but the task regex match fails, e.g. can’t find (OK XX tests) for example, then the error is missing the command line, stdout or stderr. This change pushes the regex match in to projectExec, so it can produce more meaningful error messages. This duplicates the regex match done in the task itself but this is a small tradeoff.

projectExec
- Intercept all exceptions so that they all get useful error messages
- matchRegexOutputsRequired parameter
- Distinguish between command line failure or regex failure

Tasks
- Rework exceptions and error messages to be more descriptive
- Reworked CycleFinderTask exception handling

TESTED=added test: projectExec_MatchRegexFailed