### PR TITLE
Fix TestTask for zero tests + Regex Refactor

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
@@ -127,7 +127,10 @@ class CycleFinderTask extends DefaultTask {
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()
+
+        // Capturing group is the cycle count, i.e. '\d+'
         String cyclesFoundRegex = /(\d+) CYCLES FOUND/
+
         try {
             logger.debug('CycleFinderTask - projectExec:')
             Utils.projectExec(project, stdout, stderr, cyclesFoundRegex, {
@@ -166,9 +169,10 @@ class CycleFinderTask extends DefaultTask {
             if (!cyclesFoundStr?.isInteger()) {
                 String message =
                         exception.toString() + '\n' +
-                        "CycleFinder completed could not find expected output.\n" +
-                        "Failed Regex Match cyclesFoundRegex: /$cyclesFoundRegex/" +
-                        "Found: $cyclesFoundStr"
+                        'CycleFinder completed could not find expected output.\n' +
+                        'Failed Regex Match cyclesFoundRegex: ' +
+                        Utils.escapeSlashyString(cyclesFoundRegex) + '\n' +
+                        'Found: ' + cyclesFoundStr
                 throw new InvalidUserDataException(message, exception)
             }
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -204,6 +204,13 @@ class Utils {
         return paths.join(':')
     }
 
+    // Convert regex to string for display, wrapping it with /.../
+    // From Groovy-Lang: "Only forward slashes need to be escaped with a backslash"
+    // http://docs.groovy-lang.org/latest/html/documentation/#_slashy_string
+    static String escapeSlashyString(String regex) {
+        return '/' + regex.replace('/', '\\/') + '/'
+    }
+
     // Matches regex, return first match as string, must have >1 capturing group
     // Return first capture group, comparing stderr first then stdout
     // Returns null for no match
@@ -283,7 +290,7 @@ class Utils {
                     // Exception thrown here to output command line
                     throw new InvalidUserDataException(
                             'Unable to find expected expected output in stdout or stderr\n' +
-                            "Failed Regex Match: /$matchRegexOutputsRequired/")
+                            'Failed Regex Match: ' + escapeSlashyString(matchRegexOutputsRequired))
                 }
             }
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
@@ -91,10 +91,10 @@ class CycleFinderTaskTest {
 
         try {
             j2objcCycleFinder.cycleFinder()
-        } catch (Exception e) {
+        } catch (Exception exception) {
             // Catch expected exception, do verifications, then throw again
             mockProjectExec.verify()
-            throw e
+            throw exception
         }
     }
 
@@ -153,10 +153,10 @@ class CycleFinderTaskTest {
 
         try {
             j2objcCycleFinder.cycleFinder()
-        } catch (Exception e) {
+        } catch (Exception exception) {
             // Catch expected exception, do verifications, then throw again
             mockProjectExec.verify()
-            throw e
+            throw exception
         }
     }
 }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -248,7 +248,7 @@ class UtilsTest {
     // TODO: projectExec_NonZeroExit
     // Needs command line that outputs non-zero result
 
-    @Test(expected=InvalidUserDataException.class)
+    @Test
     void projectExec_HelpfulErrorMessage() {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()
@@ -263,6 +263,8 @@ class UtilsTest {
                 setStandardOutput stdout
                 setErrorOutput stderr
             })
+            assert false, 'Expected Exception'
+
         } catch (InvalidUserDataException exception) {
             String expected =
                     'org.gradle.api.InvalidUserDataException: Command Line Failed:\n' +
@@ -274,18 +276,16 @@ class UtilsTest {
                     'Error Output:\n' +
                     'fake-stderr'
             assert exception.toString().equals(expected)
-            throw exception
         }
-        assert false
     }
 
-    @Test(expected=InvalidUserDataException.class)
+    @Test
     void projectExec_MatchRegexFailed() {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()
 
-        // Trailing '\n' is to test escaping
-        String matchRegexOutputs = /(no-match\n)/
+        // String has escaped '/' and '\n' to test escaping
+        String matchRegexOutputs = /(no\/match\n)/
         try {
             Utils.projectExec(proj, stdout, stderr, matchRegexOutputs, {
                 executable 'echo'
@@ -293,21 +293,21 @@ class UtilsTest {
                 setStandardOutput stdout
                 setErrorOutput stderr
             })
+            assert false, 'Expected Exception'
+
         } catch (InvalidUserDataException exception) {
             String expected =
                     'org.gradle.api.InvalidUserDataException: Command Line Succeeded (failure cause listed below):\n' +
                     'echo echo-stdout\n' +
                     'Caused by:\n' +
                     'org.gradle.api.InvalidUserDataException: Unable to find expected expected output in stdout or stderr\n' +
-                    'Failed Regex Match: /' + matchRegexOutputs + '/\n' +
+                    'Failed Regex Match: /(no\\/match\\n)/\n' +
                     'Standard Output:\n' +
                     'echo-stdout\n' +
                     '\n' +
                     'Error Output:\n'
             assert exception.toString().equals(expected)
-            throw exception
         }
-        assert false
     }
 
     @Test
@@ -332,14 +332,20 @@ class UtilsTest {
     @Test
     void testMatchRegexOutputStreams_MatchNumber() {
         ByteArrayOutputStream ostream = new ByteArrayOutputStream()
-        ostream.write('15 CYCLES FOUND'.getBytes('utf-8'))
+        ostream.write('OK (15 tests)'.getBytes('utf-8'))
 
-        String countStr = Utils.matchRegexOutputs(ostream, ostream, /(\d+) CYCLES FOUND/)
+        String countStr = Utils.matchRegexOutputs(ostream, ostream, /OK \((\d+) tests?\)/)
         assert 15 == countStr.toInteger()
     }
 
     @Test
-    void testLogExecSpecOutput() {
+    void testEscapeSlashyString() {
+        String regex = /forward-slash:\/,newline:\n,multi-digit:\d+/
+        assert "/forward-slash:\\/,newline:\\n,multi-digit:\\d+/" == Utils.escapeSlashyString(regex)
+    }
+
+    @Test
+    void testLogDebugExecSpecOutput() {
         ExecHandleBuilder execHandleBuilder = new ExecHandleBuilder()
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()


### PR DESCRIPTION
- Standardize on slashyString for regex
- Utils.escapeSlashyString(…)
- Improve regex fail messages
- Regex capturing group comments

Introduce @Rule for exception handling:

@Rule
public ExpectedException expectedException = ExpectedException.none();

TESTED=added a few tests:
- testTaskAction_ZeroTestExpected
- testTaskAction_ZeroTestUnexpected