### PR TITLE
`.xcworkspace` warning to avoid breaking CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Within the Android application's project `build.gradle`, make it dependent on th
         compile project(':shared')
     }
 
+#### NOTE: Open `.xcworkspace` in Xcode
+
+When using the j2objcXcodeTask, open the `.xcworkspace` file in Xcode. If the `.xcodeproj` file
+is opened in Xcode then CocoaPods will fail. This will appear as an Xcode build time error:
+
+    library not found for -lPods-*-j2objc-shared
 
 ### Folder Structure
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -161,6 +161,10 @@ class XcodeTask extends DefaultTask {
                 // unrecognized errors are rethrown:
                 throw exception
             }
+            // Warning to avoid breaking CocoaPods
+            // Error: "library not found for -lPods-*-j2objc-shared"
+            // See: https://github.com/j2objc-contrib/j2objc-gradle/issues/273
+            logger.warn("NOTE: open the '.xcworkspace' file in Xcode. It will fail if you open the '.xcodeproj' file")
         }
     }
 


### PR DESCRIPTION
- Fixes #273 - “library not found for -lPods-iosApp-j2objc-shared”