### PR TITLE
MockExec (plugin class) => ExecHandleBuilder (internal Gradle class)

### DIFF
--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -84,8 +84,8 @@ class XcodeTaskTest {
                 TestingUtils.setupProject(new TestingUtils.ProjectConfig(
                         applyJavaPlugin: true,
                         createJ2objcConfig: true))
-        // TODO: should be '../ios' but that needs temp project to be subdirectory of temp dir
-        j2objcConfig.xcodeProjectDir = 'ios'
+        // Absolute Path to avoid test error: "Cannot convert relative path ios to an absolute file."
+        j2objcConfig.xcodeProjectDir = "${proj.projectDir}/ios"
         j2objcConfig.xcodeTarget = 'IosApp'
 
         // Needed for podspecDebug
@@ -107,7 +107,7 @@ class XcodeTaskTest {
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
         mockProjectExec.demandExecAndReturn(
-                'ios',  // working directory
+                "${proj.projectDir}/ios",  // working directory
                 [
                         "pod",
                         "install",


### PR DESCRIPTION
- Logging of workingDir in projectExec

Even though this uses an internal Gradle class, I think it is a better trade off than the time and risks of re-implementing the class within the plugin.