### PR TITLE
Fix resource loading for j2objc unit tests

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -105,6 +105,8 @@ class J2objcPlugin implements Plugin<Project> {
 
             // Note the '(debug|release)TestJ2objcExecutable' tasks are dynamically created by the Objective-C plugin.
             // It is specified by the testJ2objc native component in NativeCompilation.groovy.
+            // TODO: copy and run debug and release tests within j2objcTestContent at the
+            //       same time instead of destroying and recreating j2objcTestContent twice
             tasks.create(name: 'j2objcTestDebug', type: TestTask,
                     dependsOn: ['test', 'debugTestJ2objcExecutable']) {
                 group 'verification'

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -315,6 +315,7 @@ class Utils {
             boolean execSucceeded, Exception exception) {
         // Add command line and stderr to make the error message more useful
         // Chain to the original ExecException for complete stack trace
+
         String msg
         // The command line can be long, so highlight more important details below
         if (execSucceeded) {
@@ -322,6 +323,7 @@ class Utils {
         } else {
             msg = 'Command Line Failed:\n'
         }
+
         msg += execSpec.getCommandLine().join(' ') + '\n'
 
         // Working Directory appears to always be set
@@ -352,6 +354,15 @@ class Utils {
         return (exception instanceof InvalidUserDataException) &&
                // TODO: improve indentification of non-zero exits?
                (exception?.getCause() instanceof ExecException)
+    }
+
+    static WorkResult copyResources(Project proj, String sourceSetName, File destDir) {
+        return projectCopy(proj, {
+            srcSet(proj, sourceSetName, 'resources').srcDirs.each {
+                from it
+            }
+            into destDir
+        })
     }
 
     // See projectExec for explanation of the annotations.

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
@@ -97,7 +97,7 @@ class TestTaskTest {
         ))
 
         j2objcTest = (TestTask) proj.tasks.create(name: 'j2objcTest', type: TestTask) {
-            testBinaryFile = proj.file("${proj.buildDir}/testJ2objc")
+            testBinaryFile = proj.file("${proj.buildDir}/binaries/testJ2objcExecutable/debug/testJ2objc")
         }
     }
 
@@ -108,21 +108,23 @@ class TestTaskTest {
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
 
-        expectedException.expect(InvalidUserDataException.class)
-        // Error:
-        expectedException.expectMessage('Unit tests are strongly encouraged with J2ObjC')
-        // Workaround:
-        expectedException.expectMessage('testMinExpectedTests 0')
-
+        // TODO: demandDelete...(getJ2objcTestContentDir())
+        demandCopyForJ2objcTestContent(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/testJ2objc",
+                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (0 test)',  // NOTE: 'test' is singular for stdout
                 '',  // stderr
                 null)
+
+        expectedException.expect(InvalidUserDataException.class)
+        // Error:
+        expectedException.expectMessage('Unit tests are strongly encouraged with J2ObjC')
+        // Workaround:
+        expectedException.expectMessage('testMinExpectedTests 0')
 
         j2objcTest.test()
     }
@@ -134,10 +136,11 @@ class TestTaskTest {
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
         j2objcConfig.testMinExpectedTests = 0
 
+        demandCopyForJ2objcTestContent(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/testJ2objc",
+                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (0 test)',  // NOTE: 'test' is singular for stdout
@@ -154,10 +157,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        demandCopyForJ2objcTestContent(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/testJ2objc",
+                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (1 test)',  // NOTE: 'test' is singular for stdout
@@ -174,10 +178,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        demandCopyForJ2objcTestContent(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/testJ2objc",
+                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'IGNORE\nOK (2 tests)\nIGNORE',  // stdout
@@ -194,10 +199,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        demandCopyForJ2objcTestContent(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/testJ2objc",
+                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (2 testXXXX)',  // NOTE: invalid stdout fails matchRegexOutputs
@@ -207,6 +213,21 @@ class TestTaskTest {
         j2objcTest.test()
 
         mockProjectExec.verify()
+    }
+
+    private void demandCopyForJ2objcTestContent(MockProjectExec mockProjectExec) {
+        mockProjectExec.demandCopyAndReturn(
+                "$proj.projectDir/build/j2objcTestContent",
+                "$proj.projectDir/src/main/resources",
+        )
+        mockProjectExec.demandCopyAndReturn(
+                "$proj.projectDir/build/j2objcTestContent",
+                "$proj.projectDir/src/test/resources",
+        )
+        mockProjectExec.demandCopyAndReturn(
+                "$proj.projectDir/build/j2objcTestContent",
+                "$proj.projectDir/build/binaries/testJ2objcExecutable/debug/testJ2objc",
+        )
     }
 
     // TODO: test_Simple() - with some real unit tests


### PR DESCRIPTION
- Fixes #309
- Fix MockProjectExec so it can handle multiple calls
- MockProjectExec support for project.copy() verification
- Logging of workingDir in projectExec
- j2objcTestContent directory for assembling and running tests
- TestTask now has main/test resources as @InputFiles

TESTED=yes
- Added Project mocking tests:
- testProjectExec_MockProjectExec
- testProjectCopy_MockProjectExec
- testProjectCopy_MockProjectExecTwoCalls