### PR TITLE
Simplify README + other docs improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ project that uses the plugin:
 1. Add the `buildscript` and `apply plugin` lines then update X.Y.Z based on "version = 'X.Y.Z-alpha'"
 in j2objc-gradle/build.gradle
 
+```
     // File: shared/build.gradle
 
     //plugins {
@@ -41,6 +42,7 @@ in j2objc-gradle/build.gradle
     }
     apply plugin: 'java'
     apply plugin: 'com.github.j2objccontrib.j2objcgradle'
+```
 
 Note that when rapidly developing and testing changes to the plugin by building your own project,
 avoid using the Gradle daemon as issues sometimes arise with the daemon using an old version

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,67 +13,26 @@ due to support for native compilation features.
 You have to first create the [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 Go to your project folder and do ``gradle wrapper``. Refresh your Eclipse project.
 
-### How do I setup multiple related j2objc or native projects?
-You can express three kinds of dependencies within j2objcConfig:
-
-1.  The common case is that Java and j2objc Project B depends on Java and j2objc Project A,
-and you need the Project B J2ObjC generated library to depend on the Project A J2ObjC
-generated library. In this case add to B.gradle:
-    ```
-    j2objcConfig {
-        dependsOnJ2objc project(':A')
-    }
-    ```
-This kind of dependency should be inferred automatically from the corresponding Java
-dependency in the future.
-
-2.  Java and j2objc project B depends on a
-[custom native library](https://docs.gradle.org/current/userguide/nativeBinaries.html#N15F82)
-called someLibrary in native project A.  Add to B.gradle:
-    ```
-    j2objcConfig {
-        extraNativeLib project: ':A', library: 'someLibrary', linkage: 'static'
-    }
-    ```
-
-3.  Java and j2objc project B depends on library libpreBuilt pre-built outside of
-Gradle in directory /lib/SOMEPATH, with corresponding headers in /include/SOMEPATH.
-Add to B.gradle:
-    ```
-    j2objcConfig {
-        extraObjcCompilerArgs '-I/include/SOMEPATH'
-        extraLinkerArgs '-L/lib/SOMEPATH'
-        extraLinkerArgs '-lpreBuilt'
-    }
-    ```
-
-In (1) and (2), A's library will be linked in and A's headers will be available for inclusion, and
-B will automatically build after A.  (3) is not supported by Gradle's dependency management
-capabilities; you must ensure preBuilt's binary and headers are available before project B is built.
 
 ### How do I properly pass multiple arguments to j2objc?
 
 Make sure your arguments are separate strings, not a single space-concatenated string.
-```
-j2objcConfig {
-    // CORRECT
-    translateArgs '-use-arc', '-prefixes', 'file.prefixes'
 
-    // CORRECT
-    translateArgs '-use-arc'
-    translateArgs '-prefixes'
-    translateArgs 'file.prefixes'
+    j2objcConfig {
+        // CORRECT
+        translateArgs '-use-arc'
+        translateArgs '-prefixes', 'file.prefixes'
 
-    // WRONG
-    translateArgs '-use-arc -prefixes file.prefixes'
-    
-    // WRONG
-    translateArgs '-use-arc'
-    translateArgs '-prefixes file.prefixes'
-}
-```
+        // CORRECT
+        translateArgs '-use-arc', '-prefixes', 'file.prefixes'
+
+        // WRONG
+        translateArgs '-use-arc -prefixes file.prefixes'
+    }
+
 
 ### Why is my clean build failing?
+
 This is a [known issue](https://github.com/j2objc-contrib/j2objc-gradle/issues/306) if you don't
 have any tests.
 If you are doing `./gradlew clean build`, try instead `./gradlew clean && ./gradlew build`.
@@ -82,6 +41,7 @@ When you don't have any test source files, The plugin creates a placeholder to f
 creation of a test binary; this is done during project configuration phase, but `clean` deletes
 this file before `build` can use it.
 
+
 ### How do I include Java files from additional source directories?
 
 In order to include source files from sources different than ``src/main/java`` you have to
@@ -89,15 +49,13 @@ In order to include source files from sources different than ``src/main/java`` y
 For example, if you want to include files from ``src-gen/base`` both into your JAR and (translated) into
 your Objective C libraries, then add to your ``build.gradle``:
 
-```
-sourceSets {
-  main {
-    java {
-      srcDir 'src-gen/base'
+    sourceSets {
+        main {
+            java {
+                srcDir 'src-gen/base'
+            }
+        }
     }
-  }
-}
-```
 
 
 ### How do I develop with Swift?
@@ -122,12 +80,11 @@ to access from Swift code.
 
 Add the following to your configuration block. [See](https://developer.apple.com/library/mac/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html#//apple_ref/doc/uid/TP40011226-CH1-SW15).
 
-```
-j2objcConfig {
-   translateArgs '-use-arc'
-   extraObjcCompilerArgs '-fobjc-arc'
-}
-```
+    j2objcConfig {
+       translateArgs '-use-arc'
+       extraObjcCompilerArgs '-fobjc-arc'
+    }
+
 
 ### How do I call finalConfigure()?
 
@@ -146,24 +103,106 @@ call even if you do not need to customize any other `j2objConfig` option.
 See: [How do I enable ARC for my Objective-C classes?](#how-do-i-enable-arc-for-my-objective-c-classes?)
 
 
-### Advanced Cycle Finder Setup
+### How do I disable a plugin task?
+
+You can disable tasks performed by the plugin using the following configuration block in your
+`build.gradle`. This is separate and alongside the j2objcConfig settings. For example, to
+disable the `j2objcTest` task, do the following:
+
+    j2objcTest {
+        enabled = false
+    }
+
+    j2objcConfig {
+        ...
+    }
+
+
+### How do I setup multiple related j2objc or native projects?
+
+You can express three kinds of dependencies within j2objcConfig:
+
+1. The common case is that Java and j2objc Project B depends on Java and j2objc Project A,
+and you need the Project B J2ObjC generated library to depend on the Project A J2ObjC
+generated library. In this case add to B.gradle:
+
+```
+    j2objcConfig {
+        dependsOnJ2objc project(':A')
+    }
+```
+
+This kind of dependency should be inferred automatically from the corresponding Java
+dependency in the future.
+
+2. Java and j2objc project B depends on a
+[custom native library](https://docs.gradle.org/current/userguide/nativeBinaries.html#N15F82)
+called someLibrary in native project A.  Add to B.gradle:
+
+```
+    j2objcConfig {
+        extraNativeLib project: ':A', library: 'someLibrary', linkage: 'static'
+    }
+```
+
+3. Java and j2objc project B depends on library libpreBuilt pre-built outside of
+Gradle in directory /lib/SOMEPATH, with corresponding headers in /include/SOMEPATH.
+Add to B.gradle:
+
+```
+    j2objcConfig {
+        extraObjcCompilerArgs '-I/include/SOMEPATH'
+        extraLinkerArgs '-L/lib/SOMEPATH'
+        extraLinkerArgs '-lpreBuilt'
+    }
+```
+
+In (1) and (2), A's library will be linked in and A's headers will be available for inclusion, and
+B will automatically build after A.  (3) is not supported by Gradle's dependency management
+capabilities; you must ensure preBuilt's binary and headers are available before project B is built.
+
+
+### Cycle Finder Basic Setup
+
+This task is disabled by default as it requires greater sophistication to use. It runs the
+`cycle_finder` tool in the J2ObjC release to detect memory cycles in your application.
+Objects that are part of a memory cycle on iOS won't be deleted as it doesn't support
+garbage collection.
+
+The basic setup will implicitly check for 40 memory cycles - this is the expected number
+of erroneous matches with `jre_emul` library for j2objc version 0.9.6.1. This may cause
+issues if this number changes with future versions of j2objc libraries.
+
+    j2objcCycleFinder {
+        enabled = true
+    }
+
+Also see FAQ's [Advanced Cycle Finder Setup](FAQ.md#Cycle-Finder-Advanced-Setup).
+
+
+### Cycle Finder Advanced Setup
 
 This uses a specially annotated version of the `jre_emul` source that marks all the
 erroneously matched cycles such that they can be ignored. It requires downloading
 and building the J2ObjC source:
 
-1. Download the j2objc source to a directory (hereafter J2OJBC_REPO):<br>
+1. Download the j2objc source to a directory (hereafter J2OJBC_REPO):
+
     https://github.com/google/j2objc
+
 2. Within the J2OJBC_REPO, run:<br>
+
     `(cd jre_emul && make java_sources_manifest)`
+
 3. Configure j2objcConfig in build.gradle so CycleFinder uses the annotated J2ObjC source
 and whitelist. Note how this gives and expected cycles of zero.
+
 ```
-j2objcConfig {
-    cycleFinderArgs '--whitelist', 'J2OBJC_REPO/jre_emul/cycle_whitelist.txt'
-    cycleFinderArgs '--sourcefilelist', 'J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
-    cycleFinderExpectedCycles 0
-}
+    j2objcConfig {
+        cycleFinderArgs '--whitelist', 'J2OBJC_REPO/jre_emul/cycle_whitelist.txt'
+        cycleFinderArgs '--sourcefilelist', 'J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
+        cycleFinderExpectedCycles 0
+    }
 ```
 
 For more details:

--- a/README.md
+++ b/README.md
@@ -24,21 +24,18 @@ find the latest version number of the plugin:
     // File: shared/build.gradle
     plugins {
         id 'java'
-        // Modify with latest version:
-        // https://plugins.gradle.org/plugin/com.github.j2objccontrib.j2objcgradle
-        id 'com.github.j2objccontrib.j2objcgradle' version 'X.Y.Z-alpha'
+        id 'com.github.j2objccontrib.j2objcgradle' version '0.3.0-alpha'
     }
 
     // Plugin settings:
     j2objcConfig {
-        xcodeProjectDir "../ios"   // Xcode workspace directory
-        xcodeTarget "IosApp"       // iOS app target name
+        xcodeProjectDir '../ios'  // Xcode workspace directory
+        xcodeTarget 'IosApp'      // iOS app target name
 
         // Other Settings:
-        // https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L25
+        // https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L30
 
-        // You must include this call at the end of j2objcConfig, regardless of settings
-        finalConfigure()
+        finalConfigure()          // Must be last call to configuration
     }
 
 Within the Android application's project `build.gradle`, make it dependent on the `shared` project:
@@ -48,12 +45,14 @@ Within the Android application's project `build.gradle`, make it dependent on th
         compile project(':shared')
     }
 
-#### NOTE: Open .xcworkspace in Xcode
+
+### NOTE: Open .xcworkspace in Xcode
 
 When using the j2objcXcodeTask, open the `.xcworkspace` file in Xcode. If the `.xcodeproj` file
 is opened in Xcode then CocoaPods will fail. This will appear as an Xcode build time error:
 
     library not found for -lPods-*-j2objc-shared
+
 
 ### Folder Structure
 
@@ -97,25 +96,13 @@ These are the main tasks for the plugin:
     j2objcAssemble          - Builds debug/release libraries, packs targets in to fat libraries
     j2objcTest              - Runs all JUnit tests, as translated into Objective-C
     j2objcBuild             - Builds and tests all j2objc outputs.
-    j2objcXcode             - Configure Xcode to link to static library and header files
+    j2objcXcode             - Configure Xcode to link static library & header files, uses CocoaPods
 
 Note that you can use the Gradle shorthand of `$ gradlew jA` to do the `j2objcAssemble` task.
 The other shorthand expressions are `jCF, jTr, jA, jTe, jB and jX`.
 
 
-#### Task Enable and Disable
-
-You can disable tasks performed by the plugin using the following configuration block in your
-`build.gradle`. This is separate and alongside the j2objcConfig settings. For example, to
-disable the `j2objcTest` task, do the following:
-
-    j2objcTest {
-        enabled = false
-    }
-
-    j2objcConfig {
-        ...
-    }
+### Faster Development Cycle
 
 If you are developing in a tight modify-compile-test loop and using only debug binaries, you
 may want to disable the release build temporarily by adding to your `local.properties` file:
@@ -124,31 +111,14 @@ may want to disable the release build temporarily by adding to your `local.prope
 
 This should cut the j2objc build time up to 50%.  You can also do this for `j2objc.debugEnabled`.
 
-#### j2objcCycleFinder
-
-This task is disabled by default as it requires greater sophistication to use. It runs the
-`cycle_finder` tool in the J2ObjC release to detect memory cycles in your application.
-Objects that are part of a memory cycle on iOS won't be deleted as it doesn't support
-garbage collection.
-
-The basic setup will implicitly check for 40 memory cycles - this is the expected number
-of erroneous matches with `jre_emul` library for j2objc version 0.9.6.1. This may cause
-issues if this number changes with future versions of j2objc libraries.
-
-    j2objcCycleFinder {
-        enabled = true
-    }
-
-Also see FAQ's [Advanced Cycle Finder Setup](FAQ.md#Advanced-Cycle-Finder-Setup).
-
-
-### Contributing
-See [CONTRIBUTING.md](CONTRIBUTING.md#quick-start).
-
 
 ### FAQ
 
 See [FAQ.md](FAQ.md).
+
+
+### Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md#quick-start).
 
 
 ### License

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -27,7 +27,24 @@ import org.gradle.api.tasks.util.PatternSet
 import org.gradle.util.ConfigureUtil
 
 /**
- * Further configuration uses the following fields, setting them in j2objcConfig within build.gradle
+ * j2objcConfig is used to configure the plugin with the project's build.gradle.
+ *
+ * All paths are resolved using Gradle's <a href="https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#file(java.lang.Object)">project.file(...)</a>
+ *
+ *
+ * Basic Example:
+ *
+ * j2objcConfig {
+ *     xcodeProjectDir '../ios'
+ *     xcodeTarget 'IosApp'
+ *     finalConfigure()
+ * }
+ *
+ *
+ * Complex Example:
+ *
+ * TODO...
+ *
  */
 @CompileStatic
 class J2objcConfig {


### PR DESCRIPTION
README:
- Hard code the version number in README
- Fix J2objcConfig.groovy reference
- Move task disable and Basic Cycle Finder from README to FAQ

Other:
- J2objcConfig class documentation
- Improved translateArgs examples
- Style consistencies in FAQ