### PR TITLE
Exception for invalid j2objc property keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ The other shorthand expressions are `jCF, jTr, jA, jTe, jB and jX`.
 If you are developing in a tight modify-compile-test loop and using only debug binaries, you
 may want to disable the release build temporarily by adding to your `local.properties` file:
 
-    j2objc.releaseEnabled=false
+    j2objc.release.enabled=false
 
-This should cut the j2objc build time up to 50%.  You can also do this for `j2objc.debugEnabled`.
+This should cut the j2objc build time up to 50%.  You can also do this for `j2objc.debug.enabled`.
 
 
 ### FAQ

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -487,8 +487,8 @@ class J2objcConfig {
         // so these patterns find all such tasks.
 
         // Disable only if explicitly present and not true.
-        boolean debugEnabled = Boolean.parseBoolean(Utils.getLocalProperty(project, 'debugEnabled', 'true'))
-        boolean releaseEnabled = Boolean.parseBoolean(Utils.getLocalProperty(project, 'releaseEnabled', 'true'))
+        boolean debugEnabled = Boolean.parseBoolean(Utils.getLocalProperty(project, 'debug.enabled', 'true'))
+        boolean releaseEnabled = Boolean.parseBoolean(Utils.getLocalProperty(project, 'release.enabled', 'true'))
         project.tasks.all { Task task ->
             String name = task.name
             if (name.contains('j2objc') || name.contains('J2objc')) {

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -98,6 +98,34 @@ class UtilsTest {
     }
 
     @Test
+    public void testGetLocalProperty_RequestInvalidKey() {
+        File localProperties = proj.file('local.properties')
+        localProperties.write('#IGNORE')
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Requesting invalid property: requested-invalid-key')
+        // Check list of valid keys is suggested by checking for a single entry:
+        expectedException.expectMessage('debug.enabled')
+
+        Utils.getLocalProperty(proj, 'requested-invalid-key')
+    }
+
+    @Test
+    public void testGetLocalProperty_LocalPropertiesInvalidKey() {
+        File localProperties = proj.file('local.properties')
+        localProperties.write('j2objc.written-invalid-key')
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Invalid j2objc property: j2objc.written-invalid-key')
+        expectedException.expectMessage("From local.properties: $proj.projectDir/local.properties")
+        // Check list of valid keys is suggested by checking for a single entry:
+        expectedException.expectMessage('debug.enabled')
+
+        // Request a valid key
+        Utils.getLocalProperty(proj, 'debug.enabled')
+    }
+
+    @Test
     public void testJ2objcHome_LocalProperties() {
         // Write j2objc path to local.properties file within the project
         String j2objcHomeWritten = File.createTempDir('J2OBJC_HOME', '').path


### PR DESCRIPTION
- Warn if local.properties contains invalid key with ‘j2objc.’ prefix
- Warn if developer requests invalid key
- Correct unit tests referring to j2objc.debug.enabled