### PR TITLE
projectClearDir

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -113,10 +113,7 @@ class TranslateTask extends DefaultTask {
             // if the user requests it with the UNSAFE_incrementalBuildClosure argument.
             // TODO: One correct way to incrementally compile with --build-closure would be to use
             // allInputFiles someway, but this will require some research.
-            if (srcGenDir.exists()) {
-                srcGenDir.deleteDir()
-                srcGenDir.mkdirs()
-            }
+            Utils.projectClearDir(project, srcGenDir)
             srcFilesChanged = originalSrcFiles
         } else {
             boolean nonSourceFileChanged = false
@@ -194,10 +191,7 @@ class TranslateTask extends DefaultTask {
                 // A change outside of the source set directories has occurred, so an incremental build isn't possible.
                 // The most common such change is in the JAR for a dependent library, for example if Java project
                 // that this project depends on had its source changed and was recompiled.
-                if (srcGenDir.exists()) {
-                    srcGenDir.deleteDir()
-                    srcGenDir.mkdirs()
-                }
+                Utils.projectClearDir(project, srcGenDir)
                 srcFilesChanged = originalSrcFiles
             }
         }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -383,6 +383,24 @@ class Utils {
     }
 
     /**
+     * Delete a directory and recreate it using project.delete(...) and project.mkdir(...)
+     *
+     * Must be called instead of project.delete(...) to allow mocking of project calls in testing.
+     * May fail in the case where the parent directory doesn't exist. This is because it uses
+     * Project.mkdir(...) instead of File.mkdirs(...). Note that if the parameter is an
+     * @OutputDirectory, then the directory is automatically created before the task runs.
+     *
+     * @param proj Calls proj.delete(...) method and then project.mkdir(...)
+     * @param paths Variable length list of paths to be deleted, can be String or File
+     */
+    // See projectExec for explanation of the code
+    @CompileStatic(TypeCheckingMode.SKIP)
+    static boolean projectClearDir(Project proj, File path) {
+        proj.delete(path)
+        proj.mkdir(path)
+    }
+
+    /**
      * Executes command line and returns result by calling project.exec(...)
      *
      * Throws exception if command fails or non-null regex doesn't match stdout or stderr.

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
@@ -128,7 +128,7 @@ class MockProjectExec {
     }
 
     void verify() {
-        mockForProj.verify(projectProxyInstance())
+        mockForProj.verify((GroovyObject) projectProxyInstance())
     }
 
     void demandCopyAndReturn(String intoParam, String... fromParam) {
@@ -206,6 +206,16 @@ class MockProjectExec {
 
             // Assume that something was deleted
             return true
+        }
+    }
+
+    void demandDeleteThenMkDirAndReturn(String expectedPath) {
+
+        mockForProj.demand.delete { Object path ->
+            assert expectedPath == getAbsolutePath(path)
+        }
+        mockForProj.demand.mkdir { Object path ->
+            assert expectedPath == getAbsolutePath(path)
         }
     }
 


### PR DESCRIPTION
- Allows mocking of calls to project.mkdir(…)
- Currently only used in —build_closure, which isn’t tested
- Available for testing in the future