### PR TITLE
Split debug and test task output directories

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -113,6 +113,7 @@ class J2objcPlugin implements Plugin<Project> {
                 group 'verification'
                 // This transitively depends on the 'test' task from the java plugin
                 description 'Runs all tests in the generated Objective-C code'
+                buildType = 'debug'
                 testBinaryFile = file("${buildDir}/binaries/testJ2objcExecutable/debug/testJ2objc")
             }
             tasks.create(name: 'j2objcTestRelease', type: TestTask,
@@ -120,6 +121,7 @@ class J2objcPlugin implements Plugin<Project> {
                 group 'verification'
                 // This transitively depends on the 'test' task from the java plugin
                 description 'Runs all tests in the generated Objective-C code'
+                buildType = 'release'
                 testBinaryFile = file("${buildDir}/binaries/testJ2objcExecutable/release/testJ2objc")
             }
             tasks.create(name: 'j2objcTest', type: DefaultTask,

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleLibrariesTask.groovy
@@ -31,7 +31,7 @@ import org.gradle.api.tasks.TaskAction
 @CompileStatic
 class AssembleLibrariesTask extends DefaultTask {
 
-    // Generated ObjC binaries
+    // Generated ObjC libraries
     @InputDirectory
     File srcLibDir
 
@@ -52,7 +52,7 @@ class AssembleLibrariesTask extends DefaultTask {
         // We don't need to clear out the library path, our libraries can co-exist
         // with other libraries if the user wishes them to.
 
-        assert (buildType in ['Debug', 'Release'])
+        assert buildType in ['Debug', 'Release']
 
         Utils.projectCopy(project, {
             includeEmptyDirs = true

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleResourcesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleResourcesTask.groovy
@@ -25,8 +25,8 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Assemble Sources Task copies resources to assembly directories for
- * use by an iOS application.
+ * Assemble Resources Task copies main and test resources to separate
+ * assembly directories for use by an iOS application.
  */
 @CompileStatic
 class AssembleResourcesTask extends DefaultTask {
@@ -53,18 +53,7 @@ class AssembleResourcesTask extends DefaultTask {
     void assembleResources() {
         assert getDestSrcMainResDirFile().absolutePath !=
                getDestSrcTestResDirFile().absolutePath
-        copyResources('main', getDestSrcMainResDirFile())
-        copyResources('test', getDestSrcTestResDirFile())
-    }
-
-    void copyResources(String sourceSetName, File destDir) {
-        // TODO: use Sync task for greater speed
-        Utils.projectDelete(project, destDir)
-        Utils.projectCopy(project, {
-            Utils.srcSet(project, sourceSetName, 'resources').srcDirs.each { File resourceDir ->
-                from resourceDir
-            }
-            into destDir
-        })
+        Utils.syncResourcesTo(project, ['main'], getDestSrcMainResDirFile())
+        Utils.syncResourcesTo(project, ['test'], getDestSrcTestResDirFile())
     }
 }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleResourcesTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/AssembleResourcesTaskTest.groovy
@@ -42,12 +42,20 @@ class AssembleResourcesTaskTest {
     void testAssembleResources_Basic() {
         // Expected Activity
         MockProjectExec mockProjectExec = new MockProjectExec(proj, '/J2OBJC_HOME')
+
+        // Main
         mockProjectExec.demandDeleteAndReturn(
+                "${proj.projectDir}/build/j2objcOutputs/src/main/resources")
+        mockProjectExec.demandMkDirAndReturn(
                 "${proj.projectDir}/build/j2objcOutputs/src/main/resources")
         mockProjectExec.demandCopyAndReturn(
                 "${proj.projectDir}/build/j2objcOutputs/src/main/resources",
                 "${proj.projectDir}/src/main/resources")
+
+        // Test
         mockProjectExec.demandDeleteAndReturn(
+                "${proj.projectDir}/build/j2objcOutputs/src/test/resources")
+        mockProjectExec.demandMkDirAndReturn(
                 "${proj.projectDir}/build/j2objcOutputs/src/test/resources")
         mockProjectExec.demandCopyAndReturn(
                 "${proj.projectDir}/build/j2objcOutputs/src/test/resources",

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
@@ -98,6 +98,7 @@ class TestTaskTest {
 
         j2objcTest = (TestTask) proj.tasks.create(name: 'j2objcTest', type: TestTask) {
             testBinaryFile = proj.file("${proj.buildDir}/binaries/testJ2objcExecutable/debug/testJ2objc")
+            buildType = 'debug'
         }
     }
 
@@ -108,12 +109,11 @@ class TestTaskTest {
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
 
-        // TODO: demandDelete...(getJ2objcTestContentDir())
-        demandCopyForJ2objcTestContent(mockProjectExec)
+        demandCopyForJ2objcTest(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
+                        "${proj.buildDir}/j2objcTest/debug/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (0 test)',  // NOTE: 'test' is singular for stdout
@@ -136,11 +136,11 @@ class TestTaskTest {
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
         j2objcConfig.testMinExpectedTests = 0
 
-        demandCopyForJ2objcTestContent(mockProjectExec)
+        demandCopyForJ2objcTest(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
+                        "${proj.buildDir}/j2objcTest/debug/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (0 test)',  // NOTE: 'test' is singular for stdout
@@ -157,11 +157,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        demandCopyForJ2objcTestContent(mockProjectExec)
+        demandCopyForJ2objcTest(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
+                        "${proj.buildDir}/j2objcTest/debug/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (1 test)',  // NOTE: 'test' is singular for stdout
@@ -178,11 +178,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        demandCopyForJ2objcTestContent(mockProjectExec)
+        demandCopyForJ2objcTest(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
+                        "${proj.buildDir}/j2objcTest/debug/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'IGNORE\nOK (2 tests)\nIGNORE',  // stdout
@@ -199,11 +199,11 @@ class TestTaskTest {
         setupTask()
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
-        demandCopyForJ2objcTestContent(mockProjectExec)
+        demandCopyForJ2objcTest(mockProjectExec)
         mockProjectExec.demandExecAndReturn(
                 null,
                 [
-                        "${proj.buildDir}/j2objcTestContent/testJ2objc",
+                        "${proj.buildDir}/j2objcTest/debug/testJ2objc",
                         "org.junit.runner.JUnitCore",
                 ],
                 'OK (2 testXXXX)',  // NOTE: invalid stdout fails matchRegexOutputs
@@ -215,19 +215,19 @@ class TestTaskTest {
         mockProjectExec.verify()
     }
 
-    private void demandCopyForJ2objcTestContent(MockProjectExec mockProjectExec) {
-        // Delete j2objcTestResources
+    private void demandCopyForJ2objcTest(MockProjectExec mockProjectExec) {
+        // Delete test directory
         mockProjectExec.demandDeleteAndReturn(
-                "$proj.projectDir/build/j2objcTestContent")
-        // Copy main resources, test resources and test binary to j2objcTestResources
+                "$proj.projectDir/build/j2objcTest/debug")
+        // Copy main resources, test resources and test binary to test directory
+        mockProjectExec.demandMkDirAndReturn(
+                "$proj.projectDir/build/j2objcTest/debug")
         mockProjectExec.demandCopyAndReturn(
-                "$proj.projectDir/build/j2objcTestContent",
-                "$proj.projectDir/src/main/resources")
-        mockProjectExec.demandCopyAndReturn(
-                "$proj.projectDir/build/j2objcTestContent",
+                "$proj.projectDir/build/j2objcTest/debug",
+                "$proj.projectDir/src/main/resources",
                 "$proj.projectDir/src/test/resources")
         mockProjectExec.demandCopyAndReturn(
-                "$proj.projectDir/build/j2objcTestContent",
+                "$proj.projectDir/build/j2objcTest/debug",
                 "$proj.projectDir/build/binaries/testJ2objcExecutable/debug/testJ2objc")
     }
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -335,8 +335,26 @@ class UtilsTest {
     }
 
     @Test
+    void testSyncResourcesTo() {
+        proj.pluginManager.apply(JavaPlugin)
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, '/J2OBJC_HOME')
+        mockProjectExec.demandDeleteAndReturn(
+                "$proj.projectDir/SYNC_DIR")
+        mockProjectExec.demandMkDirAndReturn(
+                "$proj.projectDir/SYNC_DIR")
+        mockProjectExec.demandCopyAndReturn(
+                "$proj.projectDir/SYNC_DIR",
+                "$proj.projectDir/src/main/resources",
+                "$proj.projectDir/src/test/resources")
+
+        Utils.syncResourcesTo(proj, ['main', 'test'], proj.file('SYNC_DIR'))
+
+        mockProjectExec.verify()
+    }
+
+    @Test
     // Tests intercepting and verifying call to project.copy(...)
-    void testProjectCopy_MockProjectExec() {
+    void testProjectCopy() {
 
         MockProjectExec mockProjectExec = new MockProjectExec(proj, '/J2OBJC_HOME')
         mockProjectExec.demandCopyAndReturn(
@@ -353,7 +371,7 @@ class UtilsTest {
 
     @Test
     // Tests intercepting and verifying call to project.exec(...)
-    void testProjectCopy_MockProjectExecTwoCalls() {
+    void testProjectCopy_TwoCalls() {
         MockProjectExec mockProjectExec = new MockProjectExec(proj, '/J2OBJC_HOME')
         mockProjectExec.demandCopyAndReturn(
                 '/DEST-1',
@@ -376,7 +394,7 @@ class UtilsTest {
 
     @Test
     // Tests intercepting and verifying call to project.delete(path1, path2)
-    void testProjectDelete_MockProjectExec() {
+    void testProjectDelete() {
         MockProjectExec mockProjectExec = new MockProjectExec(proj, '/J2OBJC_HOME')
 
         mockProjectExec.demandDeleteAndReturn('/PATH1', '/PATH2')
@@ -498,8 +516,7 @@ class UtilsTest {
     }
 
     @Test
-    // Tests intercepting and verifying call to project.exec(...)
-    void testProjectExec_MockProjectExec() {
+    void testProjectExec_ThrowException() {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()
 


### PR DESCRIPTION
Please review PR #320 first.

Now writes to two separate directories:
- j2objcTest/debug
- j2objcTest/release
- buildType @Input for TestTask

Consolidate resource copying to `syncResources` method. This should
be replaced with a more efficient copying system, e.g. rsync.