### PR TITLE
OS specific File.pathSeparator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,11 +125,12 @@ String message = "the count is negative"  // WRONG - only needed for $var interp
 ```
 
 * Regexes should be written and displayed as
-[http://docs.groovy-lang.org/latest/html/documentation/#_slashy_string](Slashy Strings):
+[Slashy Strings](http://docs.groovy-lang.org/latest/html/documentation/#_slashy_string):
 ```
-String regex = /dot-star:.*,forward-slash:\/,newline:\n/
+String regex = /dot-star:.*, forward-slash:\/, newline:\n/
 logger.debug('Regex is: ' + Utils.escapedSlashyString(regex))
-// Debug log: '/dot-star:.*,forward-slash:\/,newline:\n/'
+
+// Debug log: '/dot-star:.*, forward-slash:\/, newline:\n/'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ be run as follows:
 
     ./gradlew shared:build
 
-To update the existing Xcode project to load the libraries and header files:
+During development, to build the libraries and update Xcode (skipping the tests):
 
     ./gradlew shared:j2objcXcode
 
-Typically they should both be used together:
+For a complete build, run both:
 
     ./gradlew shared:build shared:j2objcXcode
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
@@ -124,7 +124,8 @@ class CycleFinderTask extends DefaultTask {
                 project.files(Utils.j2objcLibs(getJ2objcHome(), getTranslateJ2objcLibs()))
         ])
         // TODO: comment explaining ${project.buildDir}/classes
-        String classpathArg = Utils.joinedPathArg(classpathFiles) + ":${project.buildDir}/classes"
+        String classpathArg = Utils.joinedPathArg(classpathFiles) +
+                              File.pathSeparator + "${project.buildDir}/classes"
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -222,7 +222,8 @@ class TranslateTask extends DefaultTask {
                 project.files(Utils.j2objcLibs(getJ2objcHome(), getTranslateJ2objcLibs()))
         ])
         // TODO: comment explaining ${project.buildDir}/classes
-        String classpathArg = Utils.joinedPathArg(classpathFiles) + ":${project.buildDir}/classes"
+        String classpathArg = Utils.joinedPathArg(classpathFiles) +
+                              File.pathSeparator + "${project.buildDir}/classes"
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -250,7 +250,8 @@ class Utils {
         files.each { File file ->
             paths += file.path
         }
-        return paths.join(':')
+        // OS specific separator, i.e. ":" on OS X and ";" on Windows
+        return paths.join(File.pathSeparator)
     }
 
     static String trimTrailingForwardSlash(String path) {

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/MockProjectExec.groovy
@@ -243,8 +243,12 @@ class MockProjectExec {
 
             List<String> canonicalizedArgs = execSpec.getArgs().collect { String arg ->
                 return arg
+                        // Use '/J2OBJC_HOME' in unit tests
                         .replace(j2objcHome, j2objcHomeStd)
+                        // Use '/PROJECT_DIR' in unit tests
                         .replace(project.projectDir.path, projectDirStd)
+                        // Use ':' as path separator in unit tests, converted to ';' for Windows
+                        .replace(':', File.pathSeparator)
             }
             assert expectedCommandLine == canonicalizedArgs
             if (expectWorkingDir == null) {

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -257,10 +257,11 @@ class UtilsTest {
 
     @Test
     public void testJoinedPathArg() {
-        FileCollection fileCollection = proj.files("file1", "file2", "/absoluteFile")
+        FileCollection fileCollection = proj.files("relative_file1", "relative_file2", "/absoluteFile")
         String joinedPathArg = Utils.joinedPathArg(fileCollection)
 
-        String expected = "${proj.projectDir}/file1:${proj.projectDir}/file2:/absoluteFile"
+        String expected = "${proj.projectDir}/relative_file1:${proj.projectDir}/relative_file2:/absoluteFile"
+        expected = expected.replaceAll(':', File.pathSeparator)
         assert expected == joinedPathArg
     }
 
@@ -304,8 +305,8 @@ class UtilsTest {
 
     @Test
     void testEscapeSlashyString() {
-        String regex = /forward-slash:\/,newline:\n,multi-digit:\d+/
-        assert "/forward-slash:\\/,newline:\\n,multi-digit:\\d+/" == Utils.escapeSlashyString(regex)
+        String regex = /forward-slash:\/, newline:\n, multi-digit:\d+/
+        assert "/forward-slash:\\/, newline:\\n, multi-digit:\\d+/" == Utils.escapeSlashyString(regex)
     }
 
     @Test


### PR DESCRIPTION
- Use ":" as path separator for OS X, and ";" for Windows
- Fix unit tests to use ';' path separator on Windows

Minor changes:

- Minor improvements in README
- Corrected link in CONTRIBUTING
- Improve readability of a couple of unit tests