### PR TITLE
Add a translateOnly mode that skips compilation-dependent tasks.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -244,10 +244,12 @@ Development is officially supported only on Mac OS X. This matches the
 In practice, the j2objcCycleFinder and j2objcTranslate tasks may work, though it is
 strongly suggested to use this for experimentation only and do all proper development
 on OS X. The team will reject any bugs related to systems that don't meet the
-[minimum requirements](README.md#minimum-requirements).
+[minimum requirements](README.md#minimum-requirements). You can attempt just
+j2objcCycleFinder and j2objcTranslate by adding the following line to your local.properties
+file only on Windows machines.
 
-To experiment on Windows (skipping the unsupported tasks), the following may work:
-
-    ./gradlew shared:j2objcAssembleSource shared:j2objcAssembleResources
+```properties
+    j2objc.translateOnlyMode=true
+```
 
 Please note that this will not build the packed libraries or update your Xcode project.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -26,7 +26,6 @@ import com.github.j2objccontrib.j2objcgradle.tasks.TranslateTask
 import com.github.j2objccontrib.j2objcgradle.tasks.Utils
 import com.github.j2objccontrib.j2objcgradle.tasks.XcodeTask
 import org.gradle.api.DefaultTask
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -112,6 +111,10 @@ class J2objcPlugin implements Plugin<Project> {
                 description "Run the cycle_finder tool on all Java source files"
                 enabled false
             }
+
+            // NOTE: When adding new tasks, consider whether they fall under 'translate-only' mode, and
+            // filter them in J2objcConfig.finalConfigure otherwise.
+
             // Note the '(debug|release)TestJ2objcExecutable' tasks are dynamically created by the Objective-C plugin.
             // It is specified by the testJ2objc native component in NativeCompilation.groovy.
             // TODO: copy and run debug and release tests within j2objcTestContent at the

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -80,7 +80,8 @@ class Utils {
             Collections.unmodifiableList(Arrays.asList(
         'debug.enabled',
         'home',
-        'release.enabled'
+        'release.enabled',
+        'translateOnlyMode'
     ))
 
     private static final String PROPERTY_KEY_PREFIX = 'j2objc.'


### PR DESCRIPTION
Related to #345; Fixes #347