### PR TITLE
Enabled architectures, fixes #357

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
@@ -224,7 +224,7 @@ class NativeCompilation {
                                 }
                             }
                         }
-                        j2objcConfig.supportedArchs.each { String arch ->
+                        j2objcConfig.activeArchs.each { String arch ->
                             if (!(arch in ALL_SUPPORTED_ARCHS)) {
                                 throw new InvalidUserDataException(
                                         "Requested architecture $arch must be one of $ALL_SUPPORTED_ARCHS")

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
@@ -37,7 +37,7 @@ class PackLibrariesTask extends DefaultTask {
     @InputFiles
     ConfigurableFileCollection getLibrariesFiles() {
         String staticLibraryPath = "${project.buildDir}/binaries/${project.name}-j2objcStaticLibrary"
-        return project.files(getSupportedArchs().collect { String arch ->
+        return project.files(getActiveArchs().collect { String arch ->
             "$staticLibraryPath/$arch$buildType/lib${project.name}-j2objc.a"
         })
     }
@@ -47,7 +47,7 @@ class PackLibrariesTask extends DefaultTask {
     String buildType
 
     @Input
-    List<String> getSupportedArchs() { return J2objcConfig.from(project).supportedArchs }
+    List<String> getActiveArchs() { return J2objcConfig.from(project).activeArchs }
 
 
     @OutputDirectory

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -79,6 +79,7 @@ class Utils {
     private static final List<String> PROPERTIES_VALID_KEYS =
             Collections.unmodifiableList(Arrays.asList(
         'debug.enabled',
+        'enabledArchs',
         'home',
         'release.enabled',
         'translateOnlyMode'

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
@@ -16,6 +16,7 @@
 
 package com.github.j2objccontrib.j2objcgradle
 
+import com.github.j2objccontrib.j2objcgradle.tasks.TestingUtils
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.InvalidUserDataException
@@ -26,6 +27,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import org.testng.Assert
 
 /**
  * J2objcConfig tests.
@@ -62,8 +64,10 @@ class J2objcConfigTest {
         assert pDir + '/build/j2objcOutputs/lib' == ext.getDestLibDirFile().absolutePath
         assert pDir + '/build/j2objcOutputs/src/main/objc' == ext.getDestSrcDirFile('main', 'objc').absolutePath
         assert pDir + '/build/j2objcOutputs/src/test/objc' == ext.getDestSrcDirFile('test', 'objc').absolutePath
-        assert pDir + '/build/j2objcOutputs/src/main/resources' == ext.getDestSrcDirFile('main', 'resources').absolutePath
-        assert pDir + '/build/j2objcOutputs/src/test/resources' == ext.getDestSrcDirFile('test', 'resources').absolutePath
+        assert pDir + '/build/j2objcOutputs/src/main/resources' == ext.getDestSrcDirFile('main', 'resources')
+                .absolutePath
+        assert pDir + '/build/j2objcOutputs/src/test/resources' == ext.getDestSrcDirFile('test', 'resources')
+                .absolutePath
     }
 
     @Test
@@ -151,5 +155,45 @@ class J2objcConfigTest {
 
         String[] expected = ['-arg1', '-arg2', '-arg3']
         assert Arrays.equals(expected, j2objcConfig.extraLinkerArgs)
+    }
+
+    @Test
+    void testSupportedAndEnabledArchs_NoLocalProperties() {
+        // there is no local.properties file in this case
+        J2objcConfig j2objcConfig = new J2objcConfig(proj)
+        Assert.assertEqualsNoOrder(j2objcConfig.activeArchs.toArray(),
+                j2objcConfig.supportedArchs.toArray())
+    }
+
+    @Test
+    void testSupportedAndEnabledArchs_SubsetEnabledArchsSpecified() {
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true,
+                        extraLocalProperties: ['j2objc.enabledArchs=ios_armv7,ios_armv7s']))
+        assert j2objcConfig.activeArchs == ['ios_armv7', 'ios_armv7s']
+    }
+
+    @Test(expected = InvalidUserDataException.class)
+    void testSupportedAndEnabledArchs_SubsetAndBogusEnabledArchsSpecified() {
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true,
+                        extraLocalProperties: ['j2objc.enabledArchs=ios_armv7,bogus,ios_armv7s']))
+        j2objcConfig.getActiveArchs()
+    }
+
+    @Test
+    void testSupportedAndEnabledArchs_EmptyEnabledArchSpecified() {
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true,
+                        extraLocalProperties: ['j2objc.enabledArchs=']))
+        assert j2objcConfig.activeArchs.empty
+    }
+
+    @Test
+    void testSupportedAndEnabledArchs_NoEnabledArchsSpecified() {
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true))
+        Assert.assertEqualsNoOrder(j2objcConfig.activeArchs.toArray(),
+                j2objcConfig.supportedArchs.toArray())
     }
 }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestingUtils.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestingUtils.groovy
@@ -48,6 +48,8 @@ class TestingUtils {
         boolean createReportsDir = false
         /** the parent project for this project, if any */
         Project rootProject = null
+        /** lines to add to the local.properties file (in addition to j2objc.home) */
+        List<String> extraLocalProperties = []
     }
 
     /**
@@ -78,7 +80,9 @@ class TestingUtils {
         // To satisfy Utils.J2objcHome()
         String j2objcHome = File.createTempDir('J2OBJC_HOME', '').path
         File localProperties = proj.file('local.properties')
-        localProperties.write("j2objc.home=$j2objcHome\n")
+        List<String> localPropertiesLines = ["j2objc.home=$j2objcHome"]
+        localPropertiesLines.addAll(config.extraLocalProperties)
+        localProperties.write(localPropertiesLines.join('\n'))
 
         J2objcConfig j2objcConfig = null
         if (config.applyJ2objcPlugin) {
@@ -96,6 +100,10 @@ class TestingUtils {
         }
 
         return [proj, j2objcHome, j2objcConfig]
+    }
+
+    static J2objcConfig setupProjectJ2objcConfig(ProjectConfig config) {
+        return setupProject(config)[2] as J2objcConfig
     }
 
     static Set<? extends Task> getTaskDependencies(Project proj, String name) {


### PR DESCRIPTION
Similar to configuring debug, release, and translateOnly on a per-environment basis for developer convenience, permit enabling architectures in the environment via local.properties.

This is separate and in addition to setting the /supported/ architectures in the build file itself. The final architectures built are the intersection of the supported architectures and the per-environment enabled ones (if any).