### PR TITLE
Revert "Travis build on OS X and Linux"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: groovy
 
-os:
-  - linux
-  - osx
+# TODO: Multi-os in beta, requires approval from Travis.
+#os:
+#  - linux
+#  - osx
 
 # Everything except Java 6.
 jdk:


### PR DESCRIPTION
Reverts j2objc-contrib/j2objc-gradle#366

Per Travis support, Groovy and multiple JDK versions not yet supported on Mac.