### PR TITLE
Embed BuildInfo in plugin.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,10 +236,14 @@ published versions on plugins.gradle.org.  All branches and tags are on the
 `j2objc-contrib/j2objc-gradle` repository, not any forks.  The steps are:
 
 1.  Determine the version number.  Use https://semver.org to guide which
-slot in the version number should be bumped.  We'll call this `vX.Y.Z`.
-2.  As a separate commit, bump the version number in `build.gradle` and add a
-brief section at the top of [CHANGELOG.md](CHANGELOG.md) indicating key
-functionality and quality improvements.
+slot in the version number should be bumped.  We'll call this `vX.Y.Z`.  Note that
+this does not have to be the `-SNAPSHOT` version in build.gradle - that number
+was auto-incremented after the last release and may not reflect the extent
+of API changes which, per semantic versioning, whether to increment major, minor,
+or patch numbers.
+2.  As a separate commit, update the version number in `build.gradle`, removing the
+`-SNAPSHOT` suffix if any, and add a brief section at the top of
+[CHANGELOG.md](CHANGELOG.md) indicating key functionality and quality improvements.
 File a PR, and merge that PR into the release branch.
 3.  Tag the merge commit where that PR is merged into master as `vX.Y.Z` and push
 that tag to the repository.  It is important that this is not the commit for the PR.
@@ -254,6 +258,10 @@ git push upstream v0.4.1-alpha
 ```sh
 ./gradlew clean build publishPlugins
 ```
+
+5.  Push a new PR that increments build.gradle to `vX.Y.(Z+1)-SNAPSHOT`.  `-SNAPSHOT`
+is standard convention for marking an unofficial build (if users happen to get their
+hands on one built directly from source).
 
 ### Hotfixes
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 // Based on https://plugins.gradle.org/docs/publish-plugin
 
 plugins {
     id "com.gradle.plugin-publish" version "0.9.0"
+    // Outputs a BuildInfo.java file with information about the git repo;
+    // also fails plugin publishing if your git working directory is unclean.
+    // Note this only enforces that the code you are publishing is committed
+    // to your local repo; you have to make sure to push it upstream.
+    id "com.madvay.tools.build.gitbuildinfo" version "0.1.2-alpha"
 }
 apply plugin: 'groovy'
 
@@ -32,7 +36,11 @@ task wrapper(type: Wrapper) {
 }
 
 group = 'com.github.j2objccontrib.j2objcgradle'
-version = '0.4.2-alpha'
+
+// A suffix of -SNAPSHOT means this is not an official release of the
+// system, but built from an intermediate source tree.  See
+// CONTRIBUTING.md on how to update this version number.
+version = '0.4.3-alpha-SNAPSHOT'
 
 test {
     testLogging {
@@ -67,4 +75,9 @@ project.tasks.all {
     if (it.name == 'publishPluginGroovyDocsJar' || it.name == 'publishPluginJavaDocsJar') {
         it.from(project.file('src/main/resources/'))
     }
+}
+
+buildStamp {
+    repoBaseUrl "https://github.com/j2objc-contrib/j2objc-gradle/tree/"
+    packageName "com.github.j2objccontrib.j2objcgradle"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Jun 04 17:07:20 PDT 2015
+#Sun Aug 23 17:53:01 PDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -39,6 +39,22 @@ class J2objcPlugin implements Plugin<Project> {
   
     @Override
     void apply(Project project) {
+        String version = BuildInfo.VERSION
+        String commit = BuildInfo.GIT_COMMIT
+        String url = BuildInfo.URL
+        String timestamp = BuildInfo.TIMESTAMP
+        project.logger.info("j2objc-gradle plugin: Version $version, Built: $timestamp, Commit: $commit, URL: $url")
+        if (!BuildInfo.GIT_IS_CLEAN) {
+            project.logger.error('j2objc-gradle plugin was built with local modification.\n' +
+                                 'If you encounter issues, please use an official release from:\n' +
+                                 '    https://github.com/j2objc-contrib/j2objc-gradle/releases')
+        }
+        if (version.contains('SNAPSHOT')) {
+            project.logger.warn('j2objc-gradle plugin was built outside of an official release.\n' +
+                                'If you encounter issues, please use an official release from:\n' +
+                                '    https://github.com/j2objc-contrib/j2objc-gradle/releases')
+        }
+
         // This avoids a lot of "project." prefixes, such as "project.tasks.create"
         project.with {
             Utils.checkMinGradleVersion(GradleVersion.current())


### PR DESCRIPTION
- Display version, etc. info on startup
- Warn if using an unofficial release
- Determine whether build was clean (git-wise)

Fixes #394 

Based on:
https://gist.github.com/advayDev1/56ac2d57d072364adc79