### PR TITLE
Detect Windows and Linux and warn if not supported

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -259,15 +259,16 @@ For more details:
 - https://groups.google.com/forum/#!msg/j2objc-discuss/2fozbf6-liM/R83v7ffX5NMJ
 
 
-### How do I develop on Windows?
+### How do I develop on Windows or Linux?
 
-Windows support is limited to the j2objcCycleFinder and j2objcTranslate tasks. Windows can't
-support j2objcTest, j2objcXcode or the library packing (see [task descriptions](README.md#tasks)).
-Complete development on iOS is supported only on Mac OS X. This matches the
+Windows and Linux support is limited to the j2objcCycleFinder and j2objcTranslate tasks.
+Mac OS X is required for the j2objcAssemble, j2objcTest and j2objcXcode tasks
+(see [task descriptions](README.md#tasks)) This matches the
 [J2ObjC Requirements](http://j2objc.org/#requirements).
 
-It is recommended that Windows users use translateOnlyMode to reduce the chances of breaking the
-iOS / OS X build. This can be done by the Windows developers configuring their local.properties:
+It is recommended that Windows and Linux users use `translateOnlyMode` to reduce the chances
+of breaking the iOS / OS X build. This can be done by those developers configuring their
+local.properties (the Mac OS X developers should not use this):
 
 ```properties
 # File: local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ test {
         // of just pointing to an HTML file.
         exceptionFormat = 'full'
     }
+    systemProperty 'inTestMustFakeOS', 'true'
 }
 
 pluginBundle {

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -561,6 +561,10 @@ class J2objcConfig {
         boolean translateOnlyMode = this.translateOnlyMode ||
                                     Boolean.parseBoolean(Utils.getLocalProperty(project, 'translateOnlyMode', 'false'))
 
+        if (!translateOnlyMode) {
+            Utils.requireMacOSX('Native Compilation of translated code task')
+        }
+
         project.tasks.all { Task task ->
             String name = task.name
             // For convenience, disable all debug and/or release tasks if the user desires.
@@ -586,9 +590,8 @@ class J2objcConfig {
                 }
             }
         }
-
-
     }
+
     boolean isFinalConfigured() {
         return finalConfigured
     }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -59,11 +59,6 @@ class J2objcPlugin implements Plugin<Project> {
         project.with {
             Utils.checkMinGradleVersion(GradleVersion.current())
 
-            if (Utils.isWindows()) {
-                logger.warn('Windows is officially unsupported:\n' +
-                            'https://github.com/j2objc-contrib/j2objc-gradle/blob/master/FAQ.md#can-i-develop-on-windows')
-            }
-
             extensions.create('j2objcConfig', J2objcConfig, project)
 
             afterEvaluate { Project evaluatedProject ->

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTask.groovy
@@ -58,14 +58,10 @@ class PackLibrariesTask extends DefaultTask {
 
     @TaskAction
     void packLibraries() {
+        Utils.requireMacOSX('j2objcPackLibraries task')
+
         Utils.projectDelete(project, getOutputLibDirFile())
         getOutputLibDirFile().mkdirs()
-
-        if (Utils.isWindows()) {
-            throw new InvalidUserDataException(
-                    'Windows is officially unsupported. The packLibraries task can only be run on Mac OS X:\n' +
-                    'https://github.com/j2objc-contrib/j2objc-gradle/blob/master/FAQ.md#can-i-develop-on-windows')
-        }
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
         ByteArrayOutputStream stderr = new ByteArrayOutputStream()

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTask.groovy
@@ -94,6 +94,8 @@ class TestTask extends DefaultTask {
 
     @TaskAction
     void test() {
+        Utils.requireMacOSX('j2objcTest task')
+
         // list of test names: ['com.example.dir.ClassOneTest', 'com.example.dir.ClassTwoTest']
         // depends on "--prefixes dir/prefixes.properties" in translateArgs
         Properties packagePrefixes = Utils.packagePrefixes(project, translateArgs)

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -60,8 +60,43 @@ class Utils {
         }
     }
 
+    @VisibleForTesting
+    static String fakeOSName = ''
+
+    @VisibleForTesting
+    static String getLowerCaseOSName() {
+
+        String osName = System.getProperty('os.name')
+        if (!fakeOSName.isEmpty()) {
+            osName = fakeOSName
+        } else {
+            if (System.getProperty('inTestMustFakeOS') == 'true') {
+                throw new InvalidUserDataException(
+                        "Tests must set Utils.fakeOSName = 'OS NAME'\n" +
+                        "This ensure that tests don't depend on the system environment")
+            }
+        }
+        osName = osName.toLowerCase()
+        return osName
+    }
+
     static boolean isWindows() {
-        return System.getProperty('os.name').toLowerCase().contains('windows')
+        String osName = getLowerCaseOSName()
+        return osName.contains('windows')
+    }
+
+    static boolean isMacOSX() {
+        String osName = getLowerCaseOSName()
+        // From: http://stackoverflow.com/a/18417382/1509221
+        return osName.contains('mac') || osName.contains('darwin')
+    }
+
+    static void requireMacOSX(String taskName) {
+        if (!isMacOSX()) {
+            throw new InvalidUserDataException(
+                    "Mac OS X is required for $taskName. Use `translateOnlyMode` on Windows or Linux:\n" +
+                    'https://github.com/j2objc-contrib/j2objc-gradle/blob/master/FAQ.md#how-do-i-develop-on-windows-or-linux')
+        }
     }
 
     static void throwIfNoJavaPlugin(Project proj) {

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -86,6 +86,7 @@ class XcodeTask extends DefaultTask {
 
     @TaskAction
     void xcodeConfig() {
+        Utils.requireMacOSX('j2objcXcode task')
 
         verifyXcodeArgs()
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
@@ -17,6 +17,7 @@
 package com.github.j2objccontrib.j2objcgradle
 
 import com.github.j2objccontrib.j2objcgradle.tasks.TestingUtils
+import com.github.j2objccontrib.j2objcgradle.tasks.Utils
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.InvalidUserDataException
@@ -71,8 +72,34 @@ class J2objcConfigTest {
     }
 
     @Test
-    void testFinalConfigure() {
+    void testFinalConfigure_MacOSX() {
+        Utils.fakeOSName = 'Mac OS X'
         J2objcConfig ext = new J2objcConfig(proj)
+
+        assert !ext.finalConfigured
+        ext.finalConfigure()
+        assert ext.finalConfigured
+    }
+
+    @Test
+    void testFinalConfigure_nonMacOSX_translateOnlyMode() {
+        Utils.fakeOSName = 'Windows'
+        J2objcConfig ext = new J2objcConfig(proj)
+        assert !ext.finalConfigured
+        ext.translateOnlyMode = true
+
+        ext.finalConfigure()
+        assert ext.finalConfigured
+    }
+
+    // This protect against trying the native compile on a nonMacOSX system
+    @Test
+    void testFinalConfigure_nonMacOSX_unsupported() {
+        Utils.fakeOSName = 'Windows'
+        J2objcConfig ext = new J2objcConfig(proj)
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Mac OS X is required for Native Compilation of translated code')
 
         assert !ext.finalConfigured
         ext.finalConfigure()

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/MultiProjectTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/MultiProjectTest.groovy
@@ -1,6 +1,7 @@
 package com.github.j2objccontrib.j2objcgradle
 
 import com.github.j2objccontrib.j2objcgradle.tasks.TestingUtils
+import com.github.j2objccontrib.j2objcgradle.tasks.Utils
 import groovy.util.logging.Slf4j
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
@@ -21,6 +22,7 @@ class MultiProjectTest {
 
     @Before
     void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
         // We can't use _ for unused slots because the other variables have already been declared above.
         Object unused
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
@@ -34,6 +34,7 @@ class CycleFinderTaskTest {
 
     @Before
     void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
         (proj, j2objcHome, j2objcConfig) = TestingUtils.setupProject(new TestingUtils.ProjectConfig(
                 applyJavaPlugin: true,
                 createReportsDir: true,
@@ -58,6 +59,36 @@ class CycleFinderTaskTest {
                 null,
                 [
                         '/J2OBJC_HOME/cycle_finder',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
+                ],
+                'IGNORE\n40 CYCLES FOUND\nIGNORE',  // stdout
+                null,  // stderr
+                new ExecException('Non-Zero Exit'))
+
+        j2objcCycleFinder.cycleFinder()
+
+        mockProjectExec.verify()
+    }
+
+    @Test
+    void cycleFinder_Windows() {
+        Utils.fakeOSName = 'Windows'
+
+        // Expected number of cycles when using simple method
+        assert 40 == j2objcConfig.cycleFinderExpectedCycles
+
+        CycleFinderTask j2objcCycleFinder = (CycleFinderTask) proj.tasks.create(
+                name: 'j2objcCycleFinder', type: CycleFinderTask) {
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExecAndReturn(
+                null,
+                [
+                        'java',
+                        '-jar',
+                        '/J2OBJC_HOME/lib/cycle_finder.jar',
                         '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes',
                 ],

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
@@ -18,9 +18,12 @@ package com.github.j2objccontrib.j2objcgradle.tasks
 
 import com.github.j2objccontrib.j2objcgradle.J2objcConfig
 import com.github.j2objccontrib.j2objcgradle.NativeCompilation
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 /**
  * TestTask tests.
@@ -31,12 +34,31 @@ class PackLibrariesTaskTest {
     private String j2objcHome
     private J2objcConfig j2objcConfig
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     @Before
     void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
         (proj, j2objcHome, j2objcConfig) = TestingUtils.setupProject(new TestingUtils.ProjectConfig(
                 applyJavaPlugin: true,
                 createJ2objcConfig: true
         ))
+    }
+
+    @Test
+    void testPackLibraries_nonMacOSX() {
+        Utils.fakeOSName = 'Windows'
+
+        PackLibrariesTask j2objcPackLibraries =
+                (PackLibrariesTask) proj.tasks.create(name: 'j2objcPackLibraries', type: PackLibrariesTask) {
+                    buildType = 'Debug'
+                }
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Mac OS X is required for j2objcPackLibraries task')
+
+        j2objcPackLibraries.packLibraries()
     }
 
     @Test
@@ -62,7 +84,7 @@ class PackLibrariesTaskTest {
         assert NativeCompilation.ALL_SUPPORTED_ARCHS.size() == 5, 'Need to update list of arguments above'
 
         PackLibrariesTask j2objcPackLibraries =
-                (PackLibrariesTask) proj.tasks.create(name: 'j2objcPL', type: PackLibrariesTask) {
+                (PackLibrariesTask) proj.tasks.create(name: 'j2objcPackLibraries', type: PackLibrariesTask) {
                     buildType = 'Debug'
                 }
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TestTaskTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -38,6 +39,11 @@ class TestTaskTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
+    }
 
     @Test
     void testGetTestNames_Simple() {
@@ -100,6 +106,17 @@ class TestTaskTest {
             testBinaryFile = proj.file("${proj.buildDir}/binaries/testJ2objcExecutable/debug/testJ2objc")
             buildType = 'debug'
         }
+    }
+
+    @Test
+    void testTaskAction_nonMacOSX() {
+        Utils.fakeOSName = 'Windows'
+        setupTask()
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Mac OS X is required for j2objcTest task')
+
+        j2objcTest.test()
     }
 
     @Test

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
@@ -35,6 +35,7 @@ class TranslateTaskTest {
 
     @Before
     void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
         (proj, j2objcHome, j2objcConfig) = TestingUtils.setupProject(
                 new TestingUtils.ProjectConfig(applyJavaPlugin: true, createJ2objcConfig: true))
     }
@@ -52,6 +53,29 @@ class TranslateTaskTest {
         MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
         mockProjectExec.demandExecAndReturn([
                 '/J2OBJC_HOME/j2objc',
+                '-d', '/PROJECT_DIR/build/j2objcSrcGen',
+                '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes'
+        ])
+
+        j2objcTranslate.translate(genNonIncrementalInputs())
+
+        mockProjectExec.verify()
+    }
+
+    @Test
+    void translate_Windows() {
+        Utils.fakeOSName = 'Windows'
+        TranslateTask j2objcTranslate = (TranslateTask) proj.tasks.create(
+                name: 'j2objcTranslate', type: TranslateTask) {
+            srcGenDir = proj.file("${proj.buildDir}/j2objcSrcGen")
+        }
+
+        MockProjectExec mockProjectExec = new MockProjectExec(proj, j2objcHome)
+        mockProjectExec.demandExecAndReturn([
+                'java',
+                '-jar',
+                '/J2OBJC_HOME/lib/j2objc.jar',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGen',
                 '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
                 '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/PROJECT_DIR/build/classes'

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -63,10 +63,48 @@ class UtilsTest {
     }
 
     @Test
-    void testIsWindows() {
-        // TODO: also test for correctness
-        // For now it only tests that the call runs successfully
-        Utils.isWindows()
+    void testIsMacOSX_MacOSX() {
+        Utils.fakeOSName = 'Mac OS X'
+        assert Utils.isMacOSX()
+    }
+
+    @Test
+    void testIsMacOSX_nonMacOSX() {
+        Utils.fakeOSName = 'Windows'
+        assert !Utils.isMacOSX()
+    }
+
+    @Test
+    void testRequireMacOSX_MacOSX() {
+        Utils.fakeOSName = 'Mac OS X'
+        Utils.requireMacOSX('taskName')
+    }
+
+    @Test
+    void testRequireMacOSX_nonMacOSX() {
+        Utils.fakeOSName = 'Windows'
+
+        expectedException.expect(InvalidUserDataException)
+        expectedException.expectMessage('Mac OS X is required for taskName')
+
+        Utils.requireMacOSX('taskName')
+    }
+
+    @Test
+    void testGetLowerCaseOSName_fakeOSName() {
+        Utils.fakeOSName = 'FAKEOS'
+
+        assert 'fakeos' == Utils.getLowerCaseOSName()
+    }
+
+    @Test
+    void testGetLowerCaseOSName_fakeOSNameEmpty() {
+        Utils.fakeOSName = ''
+
+        expectedException.expect(InvalidUserDataException)
+        expectedException.expectMessage("Tests must set Utils.fakeOSName = 'OS NAME'")
+
+        Utils.getLowerCaseOSName()
     }
 
     @Test(expected = InvalidUserDataException.class)

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -40,6 +40,7 @@ class XcodeTaskTest {
 
     @Before
     void setUp() {
+        Utils.fakeOSName = 'Mac OS X'
         proj = ProjectBuilder.builder().build()
     }
 
@@ -70,6 +71,26 @@ class XcodeTaskTest {
 
         // Test for fixing issue #226
         j2objcXcode.getPodfileFile()
+    }
+
+    @Test
+    void testXcodeConfig_nonMacOSX() {
+        Utils.fakeOSName = 'Windows'
+
+        String j2objcHome
+        J2objcConfig j2objcConfig
+        (proj, j2objcHome, j2objcConfig) =
+                TestingUtils.setupProject(new TestingUtils.ProjectConfig(
+                        applyJavaPlugin: true,
+                        createJ2objcConfig: true))
+
+        XcodeTask j2objcXcode = (XcodeTask) proj.tasks.create(name: 'j2objcXcode', type: XcodeTask)
+
+        expectedException.expect(InvalidUserDataException.class)
+        expectedException.expectMessage('Mac OS X is required for j2objcXcode task')
+
+        // Makes assumption that OS is checked before any other tests
+        j2objcXcode.xcodeConfig()
     }
 
     @Test


### PR DESCRIPTION
- Error on tasks when Mac OS X is required
- Corrected link to the FAQ
- FAQ now also mentions Linux alongside Windows
- Fake OS name to unit test for Mac and nonMac systems
- inTestMustFakeOS property to ensure hermetic tests

Testing:
- Mac and nonMac command lines
- Exception thrown when attempting unsupported tasks
  (j2objcTest, j2objcPackLibraries and j2objcXcode)