### PR TITLE
New CI badges for Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Android apps (natively Java), web apps (using GWT), and iOS apps (using J2ObjC).
 [![License](https://img.shields.io/github/license/j2objc-contrib/j2objc-gradle.svg)](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/LICENSE)
 [![Linux Build Status](https://img.shields.io/travis/j2objc-contrib/j2objc-gradle/master.svg?label=Linux Build)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
 [![Windows Build Status](https://img.shields.io/appveyor/ci/madvayApiAccess/j2objc-gradle/master.svg?label=Windows Build)](https://ci.appveyor.com/project/madvayApiAccess/j2objc-gradle/branch/master)
+[![Latest Release](https://img.shields.io/github/release/j2objc-gradle/j2objc-contrib.svg?label=Release)](https://github.com/j2objc-contrib/j2objc-gradle/releases)
 
 Home Page: https://github.com/j2objc-contrib/j2objc-gradle
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ of the generated files is necessary. The goal is to write an app's non-UI code
 (such as application logic and data models) in Java, which is then shared by
 Android apps (natively Java), web apps (using GWT), and iOS apps (using J2ObjC).
 
-[![Build Status](https://travis-ci.org/j2objc-contrib/j2objc-gradle.svg)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
+[![License](https://img.shields.io/github/license/j2objc-contrib/j2objc-gradle.svg)](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/LICENSE)
+[![Linux Build Status](https://img.shields.io/travis/j2objc-contrib/j2objc-gradle/master.svg?label=Linux Build)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
+[![Windows Build Status](https://img.shields.io/appveyor/ci/madvayApiAccess/j2objc-gradle/master.svg?label=Windows Build)](https://ci.appveyor.com/project/madvayApiAccess/j2objc-gradle/branch/master)
 
 Home Page: https://github.com/j2objc-contrib/j2objc-gradle
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ of the generated files is necessary. The goal is to write an app's non-UI code
 (such as application logic and data models) in Java, which is then shared by
 Android apps (natively Java), web apps (using GWT), and iOS apps (using J2ObjC).
 
-[![License](https://img.shields.io/github/license/j2objc-contrib/j2objc-gradle.svg)](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/LICENSE)
-[![Linux Build Status](https://img.shields.io/travis/j2objc-contrib/j2objc-gradle/master.svg?label=Linux Build)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
-[![Windows Build Status](https://img.shields.io/appveyor/ci/madvayApiAccess/j2objc-gradle/master.svg?label=Windows Build)](https://ci.appveyor.com/project/madvayApiAccess/j2objc-gradle/branch/master)
-[![Latest Release](https://img.shields.io/github/release/j2objc-gradle/j2objc-contrib.svg?label=Release)](https://github.com/j2objc-contrib/j2objc-gradle/releases)
+[![License](https://img.shields.io/badge/license-Apache%202.0%20License-blue.svg)](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/LICENSE)
+[![Linux Build Status](https://img.shields.io/travis/j2objc-contrib/j2objc-gradle/master.svg?label=linux build)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
+[![Windows Build Status](https://img.shields.io/appveyor/ci/madvayApiAccess/j2objc-gradle/master.svg?label=windows build)](https://ci.appveyor.com/project/madvayApiAccess/j2objc-gradle/branch/master)
 
 Home Page: https://github.com/j2objc-contrib/j2objc-gradle
 


### PR DESCRIPTION
For travis the build is registered with the org (j2objc-contrib).
For appveyor, the build must be registered with the user (madvayApiAccess).
And yes, the Windows build is correctly failing, see #402.  Fixes #400

Badges via http://shields.io/