### PR TITLE
Travis support re-enabled multi-os on our account.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ matrix:
       language: groovy
       jdk: openjdk7
       env: USING_OS=linux
-    # 'objective-c' forces a build on OS X.  The UI will still
-    # show a Linux logo, but the logs will show a Mac box.
+    # 'objective-c' forces a build on OS X.
     # Because we override the install and script commands
     # below, this works fine, even though we are actually
-    # using Groovy.  The 'os: osx' doesn't do anything unless
-    # we are using Multi-OS support, but is here for clarity.
+    # using Groovy.
     # TODO: Replace with simply `os: osx` when Travis supports groovy
     # in their multi-OS beta.
     # TODO: Figure out how to set the JDK version on OS X.


### PR DESCRIPTION
The UI and build attributes are now correct.  We still have
to do the language workaround and other hacks in here, but the
UI will now respond correctly.

#407