### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}.{branch}
+version: {build}.{branch}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: {build}.{branch}
+version: build{build}.{branch}
 pull_requests:
   do_not_increment_build_number: true
 branches:


### PR DESCRIPTION
Build numbers are sequential - makes no sense to make them decimals,
unless we had the ability to infer the version number of the project.