### PR TITLE
Guava 18.0 builds locally!

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -258,7 +258,7 @@ class J2objcConfig {
     boolean autoConfigureDeps = false
 
     /**
-     * Additional libraries that are part of the j2objc distribution.
+     * Additional Java libraries that are part of the j2objc distribution.
      * <p/>
      * For example:
      * <pre>
@@ -276,6 +276,18 @@ class J2objcConfig {
             // Libraries that don't need CycleFinder fixes
             "javax.inject-1.jar", "jsr305-3.0.0.jar",
             "mockito-core-1.9.5.jar"]
+
+    /**
+     * Additional native libraries that are part of the j2objc distribution.
+     * <p/>
+     * For example:
+     * <pre>
+     * linkJ2objcLibs = ["guava", "jsr305"]
+     * </pre>
+     */
+    // J2objc default libraries, from $J2OBJC_HOME/lib/..., without '.a' extension.
+    // TODO: auto add libraries based on java dependencies, warn on version differences
+    List<String> linkJ2objcLibs = ['guava', 'j2objc_main', 'javax_inject', 'jsr305']
 
 
     // TODO: warn if different versions than testCompile from Java plugin

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/NativeCompilation.groovy
@@ -296,7 +296,10 @@ class NativeCompilation {
 
                     // J2ObjC provided libraries and search path:
                     // TODO: should we link to all? Or just the 'standard' J2ObjC libraries?
-                    linker.args '-lguava', '-lj2objc_main', '-ljavax_inject', '-ljre_emul', '-ljsr305'
+                    linker.args '-ljre_emul'
+                    j2objcConfig.linkJ2objcLibs.each { String libArg ->
+                        linker.args "-l$libArg"
+                    }
                     linker.args "-L$j2objcPath/lib"
 
                     // J2ObjC iOS library dependencies:

--- a/systemTests/externalLibrary1/base/build.gradle
+++ b/systemTests/externalLibrary1/base/build.gradle
@@ -23,13 +23,17 @@ repositories {
 
 dependencies {
     // Intentionally testing e2e use of a built-in j2objc library, Guava.
-    compile 'com.google.guava:guava:17.0'
+    compile project(':third_party_guava')
     // Normally we would reference this as compile "com.google.code.gson:gson:2.3.1"
     compile project(':third_party_gson')
     testCompile 'junit:junit:4.12'
 }
 
 j2objcConfig {
+    // For now, default config links in prebuilt Guava; that defeats the point.
+    translateJ2objcLibs.remove("j2objc_guava.jar")
+    linkJ2objcLibs.remove("guava")
+
     autoConfigureDeps true
 
     finalConfigure()

--- a/systemTests/externalLibrary1/extended/build.gradle
+++ b/systemTests/externalLibrary1/extended/build.gradle
@@ -24,13 +24,17 @@ repositories {
 dependencies {
     compile project(':base')
     // Intentionally testing e2e use of a built-in j2objc library, Guava.
-    compile 'com.google.guava:guava:17.0'
+    compile project(':third_party_guava')
     // Normally we would reference this as compile "com.google.code.gson:gson:2.3.1"
     compile project(':third_party_gson')
     testCompile 'junit:junit:4.12'
 }
 
 j2objcConfig {
+    // For now, default config links in prebuilt Guava; that defeats the point.
+    translateJ2objcLibs.remove("j2objc_guava.jar")
+    linkJ2objcLibs.remove("guava")
+
     autoConfigureDeps true
 
     finalConfigure()

--- a/systemTests/externalLibrary1/settings.gradle
+++ b/systemTests/externalLibrary1/settings.gradle
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include ':third_party_gson', ':base', ':extended'
+include ':third_party_gson', ':third_party_guava', ':base', ':extended'

--- a/systemTests/externalLibrary1/third_party_guava/build.gradle
+++ b/systemTests/externalLibrary1/third_party_guava/build.gradle
@@ -22,19 +22,43 @@ repositories {
 }
 
 dependencies {
+    // Most recent versions of Guava's dependencies, as inferred from Guava 18's POM file
+    // (which does not specify version at all).
+    // They are all annotations only.
+    compile 'com.google.j2objc:j2objc-annotations:0.9.8'
+    compile 'com.google.code.findbugs:jsr305:3.0.0'
+    compile 'com.google.errorprone:error_prone_annotations:2.0.4'
+    compile 'org.codehaus.mojo:animal-sniffer-annotations:1.14'
+
     // j2objcTranslation causes the entire specified library
     // to be translated and built into a standalone Objective C library.
     // j2objcTranslation must always be passed a *source* jar,
     // therefore, note the ':sources' classifier.
-    j2objcTranslation 'com.google.code.gson:gson:2.3.1:sources'
+    j2objcTranslation 'com.google.guava:guava:18.0:sources'
 }
 
 j2objcConfig {
-    filenameCollisionCheck false
+    // Per https://github.com/google/j2objc/blob/0.9.8.1/guava/README.txt
+    translatePattern {
+        exclude 'com/google/common/reflect/ClassPath.java'
+    }
+
     // For now, default config links in prebuilt Guava; that defeats the point.
     translateJ2objcLibs.remove("j2objc_guava.jar")
     linkJ2objcLibs.remove("guava")
 
+    // Approximation of https://github.com/google/j2objc/blob/0.9.8.1/guava/Makefile
+    translateArgs "--segmented-headers",
+            "--extract-unsequenced",
+            "--batch-translate-max=300",
+            "--hide-private-members",
+            "--final-methods-as-functions",
+            "-q"
+
+    // Iterators and the like are common names across packages.  This library must
+    // be compiled with full directory paths.
+    filenameCollisionCheck false
+    autoConfigureDeps true
     // Almost always there are no tests provided in an external source jar.
     testMinExpectedTests 0
     finalConfigure()

--- a/systemTests/run-all.sh
+++ b/systemTests/run-all.sh
@@ -40,5 +40,10 @@ runTest multiProject1
 
 # Two gradle projects, `extended` depends on `base`. Both of them depend
 # on project `third_party_gson`, which fully translates and compiles an
-# external library (Google's Gson). This library is used in both `extended` and `base`.
+# external library (Google's Gson); and also `third_party_guava` which
+# does the same for Guava. These libraries are used in both `extended` and `base`.
+# We must rename the include directory while this test runs, otherwise the
+# code builds against the translated Guava headers provided in the j2objc dist.
+mv localJ2objcDist/j2objcDist/include/com/google/common localJ2objcDist/j2objcDist/include/com/google/common-bak
 runTest externalLibrary1
+mv localJ2objcDist/j2objcDist/include/com/google/common-bak localJ2objcDist/j2objcDist/include/com/google/common


### PR DESCRIPTION
Also allow users to select which pre-built libraries they want to link in.
For example when testing Guava builds, we can't link to the existing j2objc Guava library

TESTED=system tests added