### PR TITLE
DEFAULT_ENABLED_ARCHS="ios_arm64,ios_armv7,ios_x86_64"

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -54,23 +54,40 @@ Also see the FAQ note on [developing with Swift](#how-do-i-develop-with-swift).
 
 ### How can I speed up my build?
 
-You can reduce the build time by 50% by skipping the release binaries by adding the
-following to your root level `local.properties` file:
+You can reduce the build time by 75% by skipping the release binaries and only building
+for a subset of the architectures. The following `local.properties` will skip the release
+build and only target the modern architectures. This works for a typical developer using
+a 64-bit iPhone (5S or later) and running the iOS simulator on a 64-bit Mac (most Intel
+Macs from 2010 onwards). Developing on an iPhone 5 or earlier will require the `ios_armv7`
+architecture.
 
 ```properties
+# File: local.properties
 j2objc.release.enabled=false
+
+# Builds only for 64-bit iPhone and 64-bit Mac iOS Simulator
+j2objc.enabledArchs=ios_arm64,ios_x86_64
 ```
 
 This is helpful for a tight modify-compile-test loop using only debug binaries.
-You can also do this for `j2objc.debug.enabled`.
+The final build (of your continuous build) should build both the debug and release
+builds. You can also do this for `j2objc.debug.enabled`.
 
-If you'd rather just disable release builds for a particular run of the command line:
+If you'd rather just disable release builds for a particular run of the command line
+(the `local.properties` value overrides the environment variable, if present).
 
 ```sh
 J2OBJC_RELEASE_ENABLED=false ./gradlew build
 ```
 
-The `local.properties` value overrides the environment variable, if present.
+The `enabledArchs` options are as follows:
+
+* 'ios_arm64' => iPhone 5S, 6, 6 Plus
+* 'ios_armv7' => iPhone 4, 4S, 5
+* 'ios_i386' => iOS Simulator on 32-bit OS X
+* 'ios_x86_64' => iOS Simulator on 64-bit OS X
+
+
 
 ### What libraries are linked by default?
 
@@ -413,8 +430,8 @@ j2objcConfig {
 ```
 
 The library will be linked in and the headers available for inclusion. All prebuilt libraries
-must be fat binaries with the architectures defined by `supportedArchs` in
-[j2objcConfig.groovy](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy).
+must be fat binaries with the architectures defined by `enabledArchs`, explained in the FAQ for
+[How can I speed up my build?](#how-can-i-speed-up-my-build).
 
 
 ### How do I setup a dependency on a native library project?

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
@@ -221,8 +221,9 @@ class J2objcConfigTest {
     void testSupportedAndEnabledArchs_NoLocalProperties() {
         // there is no local.properties file in this case
         J2objcConfig j2objcConfig = new J2objcConfig(proj)
-        Assert.assertEqualsNoOrder(j2objcConfig.activeArchs.toArray(),
-                j2objcConfig.supportedArchs.toArray())
+        Assert.assertEqualsNoOrder(
+                j2objcConfig.activeArchs.toArray(),
+                ['ios_arm64','ios_armv7','ios_x86_64'] as String[])
     }
 
     @Test
@@ -242,6 +243,17 @@ class J2objcConfigTest {
     }
 
     @Test
+    void testSupportedAndEnabledArchs_AllEnabledArchsSpecified() {
+        String allSupported = NativeCompilation.ALL_SUPPORTED_ARCHS.join(',')
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true,
+                        extraLocalProperties: ["j2objc.enabledArchs=$allSupported".toString()]))
+        Assert.assertEqualsNoOrder(
+                j2objcConfig.activeArchs.toArray(),
+                ['ios_arm64','ios_armv7','ios_armv7s','ios_i386','ios_x86_64'] as String[])
+    }
+
+    @Test
     void testSupportedAndEnabledArchs_EmptyEnabledArchSpecified() {
         J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
                 new TestingUtils.ProjectConfig(createJ2objcConfig: true,
@@ -253,7 +265,8 @@ class J2objcConfigTest {
     void testSupportedAndEnabledArchs_NoEnabledArchsSpecified() {
         J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
                 new TestingUtils.ProjectConfig(createJ2objcConfig: true))
-        Assert.assertEqualsNoOrder(j2objcConfig.activeArchs.toArray(),
-                j2objcConfig.supportedArchs.toArray())
+        Assert.assertEqualsNoOrder(
+                j2objcConfig.activeArchs.toArray(),
+                ['ios_arm64','ios_armv7','ios_x86_64'] as String[])
     }
 }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
@@ -76,11 +76,9 @@ class PackLibrariesTaskTest {
                         '-create',
                         '-output', "/PROJECT_DIR/build/packedBinaries/$proj.name-j2objcStaticLibrary/iosDebug/lib$proj.name-j2objc.a",
 
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[0]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[1]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[2]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[3]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[4]}Debug/lib$proj.name-j2objc.a"
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/ios_arm64Debug/lib$proj.name-j2objc.a",
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/ios_armv7Debug/lib$proj.name-j2objc.a",
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/ios_x86_64Debug/lib$proj.name-j2objc.a"
                 ])
         assert NativeCompilation.ALL_SUPPORTED_ARCHS.size() == 5, 'Need to update list of arguments above'
 


### PR DESCRIPTION
- Speed build by defaulting to a smaller set of enabled architectures
- Remove J2objcConfig.supportedArchs setting
- Common developer use case of modern Mac but new and old iOS devices
- Fixes #443

Notes:
- ios_i386 is rarely needed to run the iOS simulator on a 32-bit Mac
- ios_armv7s was deprecated in Xcode 6 as a “standard architecture”
- See: http://stackoverflow.com/a/25398898/1509221