### PR TITLE
Default to only modern architectures

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -377,19 +377,28 @@ class J2objcConfig {
      * The three ios_arm* architectures are for iPhone and iPad devices, while
      * ios_i386 and ios_x86_64 are for their simulators.
      * <p/>
-     * Adding an unrecognized new architecture here will fail.
+     * By default, only common modern iOS architectures will be built:
+     * ios_arm64, ios_armv7, ios_x86_64.  You may choose to add any of the remaining
+     * entries from NativeCompilation.ALL_SUPPORTED_ARCHS (ios_i386 and ios_armv7s)
+     * to support all possible iOS architectures. Listing any new architectures outside of
+     * ALL_SUPPORTED_ARCHS will fail the build.
      * <p/>
      * Removing an architecture here will cause that architecture not to be built
      * and corresponding gradle tasks to not be created.
-     * <p/>
      * <pre>
      * supportedArchs = ['ios_arm64']  // Only build libraries for 64-bit iOS devices
      * </pre>
-     *
+     * The options are:
+     * <ul>
+     * <li>'ios_arm64' => iPhone 5S, 6, 6 Plus
+     * <li>'ios_armv7' => iPhone 4, 4S, 5
+     * <li>'ios_i386' => iOS Simulator on 32-bit OS X
+     * <li>'ios_x86_64' => iOS Simulator on 64-bit OS X
+     * </ul>
      * @see NativeCompilation#ALL_SUPPORTED_ARCHS
      */
     // Public to allow assignment of array of targets as shown in example
-    List<String> supportedArchs = NativeCompilation.ALL_SUPPORTED_ARCHS.clone() as List<String>
+    List<String> supportedArchs = ['ios_arm64', 'ios_armv7', 'ios_x86_64']
 
     /**
      * An architecture is active if it is both supported ({@link #supportedArchs})

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
@@ -230,6 +230,15 @@ class J2objcConfigTest {
         J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
                 new TestingUtils.ProjectConfig(createJ2objcConfig: true,
                         extraLocalProperties: ['j2objc.enabledArchs=ios_armv7,ios_armv7s']))
+        assert j2objcConfig.activeArchs == ['ios_armv7']
+    }
+
+    @Test
+    void testSupportedAndEnabledArchs_SubsetEnabledArchsSpecifiedWithAdditionalSupportedArchs() {
+        J2objcConfig j2objcConfig = TestingUtils.setupProjectJ2objcConfig(
+                new TestingUtils.ProjectConfig(createJ2objcConfig: true,
+                        extraLocalProperties: ['j2objc.enabledArchs=ios_armv7,ios_armv7s']))
+        j2objcConfig.supportedArchs += 'ios_armv7s'
         assert j2objcConfig.activeArchs == ['ios_armv7', 'ios_armv7s']
     }
 

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PackLibrariesTaskTest.groovy
@@ -15,16 +15,13 @@
  */
 
 package com.github.j2objccontrib.j2objcgradle.tasks
-
 import com.github.j2objccontrib.j2objcgradle.J2objcConfig
-import com.github.j2objccontrib.j2objcgradle.NativeCompilation
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-
 /**
  * TestTask tests.
  */
@@ -76,13 +73,11 @@ class PackLibrariesTaskTest {
                         '-create',
                         '-output', "/PROJECT_DIR/build/packedBinaries/$proj.name-j2objcStaticLibrary/iosDebug/lib$proj.name-j2objc.a",
 
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[0]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[1]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[2]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[3]}Debug/lib$proj.name-j2objc.a",
-                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${NativeCompilation.ALL_SUPPORTED_ARCHS[4]}Debug/lib$proj.name-j2objc.a"
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${j2objcConfig.supportedArchs[0]}Debug/lib$proj.name-j2objc.a",
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${j2objcConfig.supportedArchs[1]}Debug/lib$proj.name-j2objc.a",
+                        "/PROJECT_DIR/build/binaries/$proj.name-j2objcStaticLibrary/${j2objcConfig.supportedArchs[2]}Debug/lib$proj.name-j2objc.a"
                 ])
-        assert NativeCompilation.ALL_SUPPORTED_ARCHS.size() == 5, 'Need to update list of arguments above'
+        assert j2objcConfig.supportedArchs.size() == 3, 'Need to update list of arguments above'
 
         PackLibrariesTask j2objcPackLibraries =
                 (PackLibrariesTask) proj.tasks.create(name: 'j2objcPackLibraries', type: PackLibrariesTask) {


### PR DESCRIPTION
Better fix for #443 (compare vs. #444).

I think this is much simpler, makes regular users faster, and does not take away power users' ability to use all architectures.

cc: @confile 