### PR TITLE
filenameCollisionCheck defaults to false

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -292,11 +292,20 @@ class J2objcConfig {
 
     // TODO: warn if different versions than testCompile from Java plugin
     /**
-     * Makes sure that the translated filenames don't collide.
+     * Force filename collision check so prohibit two files with same name.
      * <p/>
-     * Recommended if you choose to use --no-package-directories.
+     * This will automatically be set to true when translateArgs contains
+     * '--no-package-directories'. That flag flattens the directory structure
+     * and will overwrite files with the same name.
      */
-    boolean filenameCollisionCheck = true
+    boolean forceFilenameCollisionCheck = false
+
+    // All access to filenameCollisionCheck should be done through this function
+    boolean getFilenameCollisionCheck() {
+        if (translateArgs.contains('--no-package-directories'))
+            return true
+        return forceFilenameCollisionCheck
+    }
 
     /**
      * Sets the filter on files to translate.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
@@ -86,7 +86,7 @@ class CycleFinderTask extends DefaultTask {
     Map<String, String> getTranslateSourceMapping() { return J2objcConfig.from(project).translateSourceMapping }
 
     @Input
-    boolean getFilenameCollisionCheck() { return J2objcConfig.from(project).filenameCollisionCheck }
+    boolean getFilenameCollisionCheck() { return J2objcConfig.from(project).getFilenameCollisionCheck() }
 
 
     // Output required for task up-to-date checks

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -105,7 +105,7 @@ class TranslateTask extends DefaultTask {
     Map<String, String> getTranslateSourceMapping() { return J2objcConfig.from(project).translateSourceMapping }
 
     @Input
-    boolean getFilenameCollisionCheck() { return J2objcConfig.from(project).filenameCollisionCheck }
+    boolean getFilenameCollisionCheck() { return J2objcConfig.from(project).getFilenameCollisionCheck() }
 
 
     // Generated ObjC files

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -295,7 +295,7 @@ class Utils {
                         "To disable this check (which may overwrite files), modify build.gradle:\n" +
                         "\n" +
                         "j2objcConfig {\n" +
-                        "    filenameCollisionCheck false\n" +
+                        "    forceFilenameCollisionCheck false\n" +
                         "}\n"
                 throw new InvalidUserDataException(message)
             }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfigTest.groovy
@@ -75,6 +75,20 @@ class J2objcConfigTest {
     }
 
     @Test
+    void testFilenameCollisionCheckIsSet_Default() {
+        J2objcConfig ext = new J2objcConfig(proj)
+        assert !ext.getFilenameCollisionCheck()
+    }
+
+    @Test
+    void testFilenameCollisionCheckIsSet_NoPackageDirectories() {
+        J2objcConfig ext = new J2objcConfig(proj)
+        ext.translateArgs('--no-package-directories')
+        assert !ext.forceFilenameCollisionCheck
+        assert ext.getFilenameCollisionCheck()
+    }
+
+    @Test
     void testFinalConfigure_MacOSX() {
         Utils.setFakeOSMacOSX()
         J2objcConfig ext = new J2objcConfig(proj)

--- a/systemTests/externalLibrary1/third_party_gson/build.gradle
+++ b/systemTests/externalLibrary1/third_party_gson/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 }
 
 j2objcConfig {
-    filenameCollisionCheck false
+    forceFilenameCollisionCheck false
     // For now, default config links in prebuilt Guava; that defeats the point.
     translateJ2objcLibs.remove("j2objc_guava.jar")
     linkJ2objcLibs.remove("guava")

--- a/systemTests/externalLibrary1/third_party_guava/build.gradle
+++ b/systemTests/externalLibrary1/third_party_guava/build.gradle
@@ -57,7 +57,7 @@ j2objcConfig {
 
     // Iterators and the like are common names across packages.  This library must
     // be compiled with full directory paths.
-    filenameCollisionCheck false
+    forceFilenameCollisionCheck false
     autoConfigureDeps true
     // Almost always there are no tests provided in an external source jar.
     testMinExpectedTests 0


### PR DESCRIPTION
Defaults to True when translateArgs contains “—no-package-directories”

Fixes #467