### PR TITLE
version = '0.4.4-alpha-SNAPSHOT'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ group = 'com.github.j2objccontrib.j2objcgradle'
 // A suffix of -SNAPSHOT means this is not an official release of the
 // system, but built from an intermediate source tree.  See
 // CONTRIBUTING.md on how to update this version number.
-version = '0.4.3-alpha'
+version = '0.4.4-alpha-SNAPSHOT'
 
 test {
     testLogging {


### PR DESCRIPTION
I know we'll next go to v0.5.0 but leaving it as the old version until we make that leap.