### PR TITLE
Handle autogenerated classes correctly.

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -127,18 +127,15 @@ class J2objcConfig {
 
     /**
      * Generated source files directories, e.g. from dagger annotations.
-     * <p/>
-     * The plugin will ignore changes in this directory so they must
-     * be limited to files generated solely from files within your
-     * main and/or test sourceSets.
      */
-    List<String> generatedSourceDirs = new ArrayList<>()
+    // Default location for generated source files using annotation processor compilation,
+    // per sourceSets.main.output.classesDir.
+    // However, we cannot actually access sourceSets.main.output.classesDir here, because
+    // the Java plugin convention may not be applied at this time.
+    // TODO: Add a test counterpart for this.
+    List<String> generatedSourceDirs = ['build/classes/main']
     /**
      * Add generated source files directories, e.g. from dagger annotations.
-     * <p/>
-     * The plugin will ignore changes in this directory so they must
-     * be limited to files generated solely from files within your
-     * main and/or test sourceSets.
      *
      * @param generatedSourceDirs adds generated source directories for j2objc translate
      */

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcPlugin.groovy
@@ -149,10 +149,6 @@ class J2objcPlugin implements Plugin<Project> {
                     dependsOn: 'j2objcPreBuild') {
                 group 'build'
                 description "Translates all the java source files in to Objective-C using 'j2objc'"
-                additionalMainSrcFiles = files(
-                        fileTree(dir: "build/source/apt",
-                                include: "**/*.java")
-                )
                 // Output directories of 'j2objcTranslate', input for all other tasks
                 srcGenMainDir = j2objcSrcGenMainDir
                 srcGenTestDir = j2objcSrcGenTestDir

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTask.groovy
@@ -54,7 +54,7 @@ class CycleFinderTask extends DefaultTask {
         // solely an input to this method, which is already an input (via @InputFiles).
         FileTree allFiles = Utils.srcSet(project, 'main', 'java')
         allFiles = allFiles.plus(Utils.srcSet(project, 'test', 'java'))
-        FileTree ret = allFiles
+        FileTree ret = allFiles.plus(Utils.javaTrees(project, getGeneratedSourceDirs()))
         if (J2objcConfig.from(project).translatePattern != null) {
             ret = allFiles.matching(J2objcConfig.from(project).translatePattern)
         }
@@ -64,13 +64,10 @@ class CycleFinderTask extends DefaultTask {
     // All input files that could affect translation output, except those in j2objc itself.
     @InputFiles
     UnionFileCollection getAllInputFiles() {
-        // Only care about changes in the generatedSourceDirs paths and not the contents
-        // Assumes that any changes in generated code causes change in non-generated @Input
         return new UnionFileCollection([
                 getSrcInputFiles(),
                 project.files(getTranslateClasspaths()),
-                project.files(getTranslateSourcepaths()),
-                project.files(getGeneratedSourceDirs())
+                project.files(getTranslateSourcepaths())
         ])
     }
 
@@ -122,10 +119,6 @@ class CycleFinderTask extends DefaultTask {
         // TODO: Need to understand why generated source dirs are treated differently by CycleFinder
         // vs. translate task.  Here they are directly passed to the binary, but in translate
         // they are only on the translate source path (meaning they will only be translated with --build-closure).
-
-        // Generated Files
-        // Assumes that any changes in generated code causes change in non-generated @Input
-        fullSrcFiles = fullSrcFiles.plus(Utils.javaTrees(project, getGeneratedSourceDirs()))
 
         UnionFileCollection sourcepathDirs = new UnionFileCollection([
                 project.files(Utils.srcSet(project, 'main', 'java').getSrcDirs()),

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTask.groovy
@@ -37,12 +37,8 @@ import org.gradle.api.tasks.incremental.InputFileDetails
 @CompileStatic
 class TranslateTask extends DefaultTask {
 
-    // Source files outside of the Java main sourceSet.
-    FileCollection additionalMainSrcFiles
-
-    // Note that neither additionalMainSrcFiles nor translatePattern need
-    // to be @Inputs because they are solely inputs to the 2 methods below, which
-    // are already @InputFiles.
+    // Note that translatePattern need not be @Inputs because it is solely an inputs
+    // to the 2 methods below, which are already @InputFiles.
 
     // If the j2objc distribution changes, we want to rerun the task completely.
     // As an InputFile, if the content changes, the task will re-run in non-incremental mode.
@@ -63,12 +59,8 @@ class TranslateTask extends DefaultTask {
         if (J2objcConfig.from(project).translatePattern != null) {
             allFiles = allFiles.matching(J2objcConfig.from(project).translatePattern)
         }
-        FileCollection ret = allFiles
+        FileCollection ret = allFiles.plus(Utils.javaTrees(project, getGeneratedSourceDirs()))
         ret = Utils.mapSourceFiles(project, ret, getTranslateSourceMapping())
-
-        if (additionalMainSrcFiles != null) {
-            ret = ret.plus(additionalMainSrcFiles)
-        }
         return ret
     }
 
@@ -91,7 +83,6 @@ class TranslateTask extends DefaultTask {
         allFiles += getTestSrcFiles()
         allFiles += project.files(getTranslateClasspaths())
         allFiles += project.files(getTranslateSourcepaths())
-        allFiles += project.files(getGeneratedSourceDirs())
         // Only care about changes in the generatedSourceDirs paths and not the contents
         // It assumes that any changes in generated code comes from change in non-generated code
         return allFiles

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -28,7 +28,9 @@ import org.gradle.api.Nullable
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.file.UnionFileTree
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.WorkResult
@@ -408,14 +410,10 @@ class Utils {
     }
 
     // Add list of java path to a FileCollection as a FileTree
-    static FileCollection javaTrees(Project proj, List<String> treePaths) {
-        FileCollection files = proj.files()
-        treePaths.each { String treePath ->
-            log.debug "javaTree: $treePath"
-            files = files.plus(
-                    proj.files(proj.fileTree(dir: treePath, includes: ["**/*.java"])))
-        }
-        return files
+    static FileTree javaTrees(Project proj, List<String> treePaths) {
+        List<? extends FileTree> trees =
+            treePaths.collect({ String treePath -> proj.fileTree(dir: treePath, includes: ["**/*.java"]) })
+        return new UnionFileTree("javaTrees_j2objc", trees)
     }
 
     static List<String> j2objcLibs(String j2objcHome,

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/CycleFinderTaskTest.groovy
@@ -60,7 +60,7 @@ class CycleFinderTaskTest {
                 null,
                 [
                         '/J2OBJC_HOME/cycle_finder',
-                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                 ],
                 // expectedWindowsExecutableAndArgs
@@ -94,7 +94,7 @@ class CycleFinderTaskTest {
                 null,
                 [
                         'INVALID-NEEDS-WINDOWS-SUBSTITUTION',
-                        '-sourcepath', '/PROJECT_DIR/src/main/java;/PROJECT_DIR/src/test/java',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                 ],
                 // expectedWindowsExecutableAndArgs
@@ -125,7 +125,7 @@ class CycleFinderTaskTest {
                 null,
                 [
                         '/J2OBJC_HOME/cycle_finder',
-                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                 ],
                 // expectedWindowsExecutableAndArgs
@@ -164,7 +164,7 @@ class CycleFinderTaskTest {
                 null,
                 [
                         '/J2OBJC_HOME/cycle_finder',
-                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                         '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
                         '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'
@@ -200,7 +200,7 @@ class CycleFinderTaskTest {
                 null,
                 [
                         '/J2OBJC_HOME/cycle_finder',
-                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                        '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                         '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                         '--whitelist', '/J2OBJC_REPO/jre_emul/cycle_whitelist.txt',
                         '--sourcefilelist', '/J2OBJC_REPO/jre_emul/build_result/java_sources.mf'

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/TranslateTaskTest.groovy
@@ -59,7 +59,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 '/J2OBJC_HOME/j2objc',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenMain',
-                '-sourcepath', '/PROJECT_DIR/src/main/java',
+                '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/build/classes/main',
                 '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                 '/PROJECT_DIR/src/main/java/com/example/Main.java'
         ],
@@ -73,7 +73,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 '/J2OBJC_HOME/j2objc',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenTest',
-                '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java',
+                '-sourcepath', '/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/build/classes/main',
                 '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar:/J2OBJC_HOME/lib/j2objc_guava.jar:/J2OBJC_HOME/lib/j2objc_junit.jar:/J2OBJC_HOME/lib/jre_emul.jar:/J2OBJC_HOME/lib/javax.inject-1.jar:/J2OBJC_HOME/lib/jsr305-3.0.0.jar:/J2OBJC_HOME/lib/mockito-core-1.9.5.jar:/J2OBJC_HOME/lib/hamcrest-core-1.3.jar:/J2OBJC_HOME/lib/protobuf_runtime.jar:/PROJECT_DIR/build/classes',
                 '/PROJECT_DIR/src/test/java/com/example/Verify.java'
         ],
@@ -102,7 +102,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 'INVALID-NEEDS-WINDOWS-SUBSTITUTION',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenMain',
-                '-sourcepath', '/PROJECT_DIR/src/main/java',
+                '-sourcepath', '/PROJECT_DIR/src/main/java;/PROJECT_DIR/build/classes/main',
                 '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar;/J2OBJC_HOME/lib/j2objc_guava.jar;/J2OBJC_HOME/lib/j2objc_junit.jar;/J2OBJC_HOME/lib/jre_emul.jar;/J2OBJC_HOME/lib/javax.inject-1.jar;/J2OBJC_HOME/lib/jsr305-3.0.0.jar;/J2OBJC_HOME/lib/mockito-core-1.9.5.jar;/J2OBJC_HOME/lib/hamcrest-core-1.3.jar;/J2OBJC_HOME/lib/protobuf_runtime.jar;/PROJECT_DIR/build/classes',
                 '/PROJECT_DIR/src/main/java/com/example/Main.java'
         ],
@@ -116,7 +116,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 'INVALID-NEEDS-WINDOWS-SUBSTITUTION',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenTest',
-                '-sourcepath', '/PROJECT_DIR/src/main/java;/PROJECT_DIR/src/test/java',
+                '-sourcepath', '/PROJECT_DIR/src/main/java;/PROJECT_DIR/src/test/java;/PROJECT_DIR/build/classes/main',
                 '-classpath', '/J2OBJC_HOME/lib/j2objc_annotations.jar;/J2OBJC_HOME/lib/j2objc_guava.jar;/J2OBJC_HOME/lib/j2objc_junit.jar;/J2OBJC_HOME/lib/jre_emul.jar;/J2OBJC_HOME/lib/javax.inject-1.jar;/J2OBJC_HOME/lib/jsr305-3.0.0.jar;/J2OBJC_HOME/lib/mockito-core-1.9.5.jar;/J2OBJC_HOME/lib/hamcrest-core-1.3.jar;/J2OBJC_HOME/lib/protobuf_runtime.jar;/PROJECT_DIR/build/classes',
                 '/PROJECT_DIR/src/test/java/com/example/Verify.java'
         ],
@@ -157,7 +157,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 '/J2OBJC_HOME/j2objc',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenMain',
-                '-sourcepath', "/PROJECT_DIR/src/main/java:/PROJECT_DIR/REL-SOURCEPATH:$absSourcePath:/PROJECT_DIR/REL-GENPATH:$absGenPath",
+                '-sourcepath', "/PROJECT_DIR/src/main/java:/PROJECT_DIR/REL-SOURCEPATH:$absSourcePath:/PROJECT_DIR/build/classes/main:/PROJECT_DIR/REL-GENPATH:$absGenPath",
                 '-classpath', "/PROJECT_DIR/REL-CLASSPATH:$absClassPath:/J2OBJC_HOME/lib/J2OBJC-LIB1:/J2OBJC_HOME/lib/J2OBJC-LIB2:/PROJECT_DIR/build/classes",
                 '-ARG1', '-ARG2',
                 '/PROJECT_DIR/src/main/java/com/example/Main.java'
@@ -171,7 +171,7 @@ class TranslateTaskTest {
         mockProjectExec.demandExecAndReturn([
                 '/J2OBJC_HOME/j2objc',
                 '-d', '/PROJECT_DIR/build/j2objcSrcGenTest',
-                '-sourcepath', "/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/REL-SOURCEPATH:$absSourcePath:/PROJECT_DIR/REL-GENPATH:$absGenPath",
+                '-sourcepath', "/PROJECT_DIR/src/main/java:/PROJECT_DIR/src/test/java:/PROJECT_DIR/REL-SOURCEPATH:$absSourcePath:/PROJECT_DIR/build/classes/main:/PROJECT_DIR/REL-GENPATH:$absGenPath",
                 '-classpath', "/PROJECT_DIR/REL-CLASSPATH:$absClassPath:/J2OBJC_HOME/lib/J2OBJC-LIB1:/J2OBJC_HOME/lib/J2OBJC-LIB2:/PROJECT_DIR/build/classes",
                 '-ARG1', '-ARG2',
                 '/PROJECT_DIR/src/test/java/com/example/Verify.java'


### PR DESCRIPTION
Handle autogenerated classes correctly.
- Make autogenerated files work even without --build-closure
- Handle changes to autogenerated files that are not solely caused by changes to hand-written files (ex. configuration changes).
- Default to build/classes/main for annotation-processor generated source.
- Both CycleFinder and Translate now treat autogen code identically.
- Remove duplicate functionality between 'additional' and 'generated' files.

Fixes #517 