### PR TITLE
minVersionOsx = 10.6 (new default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ New functionality:
 
 Breaking changes/functionality:
 * No longer supports Xcode 6 and lower or j2objc 0.9.8.2 and lower #483
-* Minimum versions of platforms have been reduced to iOS 6.0, OS X 10.4, and WatchOS 1.0 #512
+* Minimum versions of platforms have been configured as iOS 6.0, OS X 10.6, and WatchOS 1.0 #512
 * NOTE: watchOS is not yet supported due to lack of full bitcode support by J2ObjC 0.9.8.2.1.
-* `build/source/apt` no longer included in translation by default #527
+* Default translation dir `build/source/apt` replaced by `build/classes/main` #527
 
 Code quality:
 * Multi-project integration tests disabled temporarily (system tests are used instead) #483

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -628,8 +628,9 @@ class J2objcConfig {
      * <p/>
      * See https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html#//apple_ref/doc/uid/10000163i-CH1-SW2
      */
-    // Matches the oldest version supported in Xcode 7
-    String minVersionOsx = '10.4'
+    // Oldest OS X version that supports automatic reference counting (2009 onwards)
+    // Prevents Xcode error: "-fobjc-arc is not supported on versions of OS X prior to 10.6"
+    String minVersionOsx = '10.6'
 
     /**
      * The minimum Watch OS version to build against.  You cannot use APIs that are not supported
@@ -794,6 +795,13 @@ class J2objcConfig {
         assert destLibDir != null
         assert destSrcMainDir != null
         assert destSrcTestDir != null
+
+        // TODO: watchOS build support
+        if (xcodeTargetsWatchos.size() > 0) {
+            throw new InvalidUserDataException(
+                    "WatchOS isn't yet supported, please unset xcodeTargetsWatchos for now." +
+                    "Follow this issue for updates: https://github.com/j2objc-contrib/j2objc-gradle/issues/525")
+        }
     }
 
     protected void configureNativeCompilation() {

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PodspecTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/PodspecTaskTest.groovy
@@ -88,7 +88,7 @@ class PodspecTaskTest {
                 "    'LIBRARY_SEARCH_PATHS' => '${j2objcHome}/lib'",
                 "  }",
                 "  spec.ios.deployment_target = '6.0'",
-                "  spec.osx.deployment_target = '10.4'",
+                "  spec.osx.deployment_target = '10.6'",
                 "  spec.watchos.deployment_target = '1.0'",
                 "  spec.osx.frameworks = 'ExceptionHandling'",
                 "end"]
@@ -121,7 +121,7 @@ class PodspecTaskTest {
                 "    'LIBRARY_SEARCH_PATHS' => '${j2objcHome}/lib'",
                 "  }",
                 "  spec.ios.deployment_target = '6.0'",
-                "  spec.osx.deployment_target = '10.4'",
+                "  spec.osx.deployment_target = '10.6'",
                 "  spec.watchos.deployment_target = '1.0'",
                 "  spec.osx.frameworks = 'ExceptionHandling'",
                 "end"]

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -41,7 +41,7 @@ class XcodeTaskTest {
             new XcodeTask.XcodeTargetDetails(
                     ['IOS-APP'], [], [],
                     // Append '.0' to version number to check that it's not using defaults
-                    '6.0.0', '10.4.0', '1.0.0')
+                    '6.0.0', '10.6.0', '1.0.0')
     List<XcodeTask.PodspecDetails> podspecDetailsProj =
             [new XcodeTask.PodspecDetails(
                 'PROJ',
@@ -130,7 +130,7 @@ class XcodeTaskTest {
 
         j2objcConfig.xcodeProjectDir = '../ios'
         j2objcConfig.xcodeTargetsIos = ['IOS-APP', 'IOS-APPTests']
-        j2objcConfig.minVersionIos = '6.0.0'
+        j2objcConfig.minVersionIos = '6.1.0'
 
         // Podfile Write
         // This is outside of the project's temp directory but appears to work fine
@@ -183,12 +183,12 @@ class XcodeTaskTest {
                 "end",
                 "",
                 "target 'IOS-APP' do",
-                "    platform :ios, '6.0.0'",
+                "    platform :ios, '6.1.0'",
                 "    $podNameMethod",
                 "end",
                 "",
                 "target 'IOS-APPTests' do",
-                "    platform :ios, '6.0.0'",
+                "    platform :ios, '6.1.0'",
                 "    $podNameMethod",
                 "end"]
         List<String> readPodfileLines = podfile.readLines()
@@ -494,7 +494,7 @@ class XcodeTaskTest {
                 "end"]
         XcodeTask.XcodeTargetDetails xcodeTargetDetails = new XcodeTask.XcodeTargetDetails(
                 ['IOS-APP'], ['OSX-APP'], ['WATCH-APP'],
-                '6.0.0', '10.4.0', '1.0.0')
+                '6.0.0', '10.6.0', '1.0.0')
 
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
@@ -516,7 +516,7 @@ class XcodeTaskTest {
                 "    j2objc_PROJ",
                 "end",
                 "target 'OSX-APP' do",
-                "    platform :osx, '10.4.0'",
+                "    platform :osx, '10.6.0'",
                 "    j2objc_PROJ",
                 "end",
                 "target 'WATCH-APP' do",
@@ -552,7 +552,7 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         [], [], [],
-                        '6.0.0', '10.4.0', '1.0.0'),
+                        '6.0.0', '10.6.0', '1.0.0'),
                 null)
     }
 
@@ -573,7 +573,7 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         ['TARGET-DOES-NOT-EXIST'], [], [],
-                        '6.0.0', '10.4.0', '1.0.0'),
+                        '6.0.0', '10.6.0', '1.0.0'),
                 null)
     }
 
@@ -710,7 +710,7 @@ class XcodeTaskTest {
                 podspecDetailsProj,
                 new XcodeTask.XcodeTargetDetails(
                         ['IOS-APP-B'], [], [],
-                        '6.0.0', '10.4.0', '1.0.0'))
+                        '6.0.0', '10.6.0', '1.0.0'))
         List<String> expectedPodfileLinesAfterSwap = [
                 "target 'IOS-APP' do",
                 "end",
@@ -745,7 +745,7 @@ class XcodeTaskTest {
                  new XcodeTask.PodspecDetails('PROJ_B', null, null)],
                 new XcodeTask.XcodeTargetDetails(
                         ['IOS-APP', 'IOS-APPTests'], ['OSX-APP', 'OSX-APPTests'], ['WATCH-APP', 'WATCH-APPTests'],
-                        '6.0.0', '10.4.0', '1.0.0'))
+                        '6.0.0', '10.6.0', '1.0.0'))
 
         List<String> expectedPodfileLines = [
                 "target 'IOS-APP' do",
@@ -759,12 +759,12 @@ class XcodeTaskTest {
                 "    j2objc_PROJ_B",
                 "end",
                 "target 'OSX-APP' do",
-                "    platform :osx, '10.4.0'",
+                "    platform :osx, '10.6.0'",
                 "    j2objc_PROJ_A",
                 "    j2objc_PROJ_B",
                 "end",
                 "target 'OSX-APPTests' do",
-                "    platform :osx, '10.4.0'",
+                "    platform :osx, '10.6.0'",
                 "    j2objc_PROJ_A",
                 "    j2objc_PROJ_B",
                 "end",
@@ -821,6 +821,6 @@ class XcodeTaskTest {
                 podspecDetailsProj,
                 new XcodeTask.XcodeTargetDetails(
                         ['TARGET-DOES-NOT-EXIST'], [], [],
-                        '6.0.0', '10.4.0', '1.0.0'))
+                        '6.0.0', '10.6.0', '1.0.0'))
     }
 }

--- a/systemTests/allPlatforms/local.properties
+++ b/systemTests/allPlatforms/local.properties
@@ -1,1 +1,1 @@
-systemTests/common/local.properties
+../common/local.properties

--- a/systemTests/allPlatforms/shared/build.gradle
+++ b/systemTests/allPlatforms/shared/build.gradle
@@ -30,14 +30,9 @@ j2objcConfig {
 
     xcodeTargetsIos 'IOS-APP', 'IOS-APPTests'
     xcodeTargetsOsx 'OSX-APP', 'OSX-APPTests'
+
+    // TODO: minVersionWatchos '2.0'  // min version for native app
     // TODO: xcodeTargetsWatchos 'WATCH-APP', 'WATCH-APPTests'
-
-    // TODO: should we fix to work on 10.5 and earlier?
-    // clang: error: -fobjc-arc is not supported on versions of OS X prior to 10.6
-    minVersionOsx '10.6'
-
-    // TODO: 'WATCH-APP', 'WATCH-APP Extension'
-    // TODO: minVersionWatchos '2.0'
 
     finalConfigure()
 }


### PR DESCRIPTION
- minVersionOsx now defaults to 10.6 (oldest version that supports ARC)
- exception thrown for unsupported watchOS (manually tested)

allPlatforms
- clean up shared/build.gradle
- correct symlink for local.properties