### PR TITLE
Gradle cache on CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ branches:
 sudo: false
 
 # Gradle Cache
-# Avoids uploading the cache after every build
+# Avoid uploading the cache after every build
 # http://docs.travis-ci.com/user/languages/android/#Default-Test-Command-for-Gradle
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,18 @@ branches:
 # We can be run in a container for improved performance.
 sudo: false
 
+# Gradle Cache
+# Avoids uploading the cache after every build
+# http://docs.travis-ci.com/user/languages/android/#Default-Test-Command-for-Gradle
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    # TODO: match systemTest directories as well?
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+
 before_install:
   # Don't spew graphic art.
   - export TERM=dumb


### PR DESCRIPTION
- Caches `$HOME/.gradle/caches/` and `$HOME/.gradle/wrapper/`

- Remove lock file to prevent upload of essentially unmodified cache

    $HOME/.gradle/caches/modules-2/modules-2.lock