### PR TITLE
Android CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,17 @@ matrix:
     - os: linux
       language: groovy
       jdk: oraclejdk7
-      env: USING_OS=linux
+      env:
+        # Trick to run no tests
+        - TEST_SET=NONE
+        - USING_OS=linux
     - os: linux
-      language: groovy
+      language: android
       jdk: openjdk7
-      env: USING_OS=linux
+      env:
+        - TEST_SET=1
+        - USING_OS=linux
+        - J2OBJC_TRANSLATE_ONLY=true
     # 'objective-c' forces a build on OS X.
     # Because we override the install and script commands
     # below, this works fine, even though we are actually
@@ -22,18 +28,25 @@ matrix:
       osx_image: xcode7
       language: objective-c
       env:
-       - TEST_SET=1
-       - USING_OS=osx
-       - USING_XCODE=7
+        - TEST_SET=1
+        - USING_OS=osx
+        - USING_XCODE=7
+        - ANDROID_BUILD_DISABLED=true
     # Split up the system tests into 2 sets to avoid hitting the
     # max build time.
     - os: osx
       osx_image: xcode7
       language: objective-c
       env:
-       - TEST_SET=2
-       - USING_OS=osx
-       - USING_XCODE=7
+        - TEST_SET=2
+        - USING_OS=osx
+        - USING_XCODE=7
+        - ANDROID_BUILD_DISABLED=true
+
+android:
+  components:
+    - build-tools-21.1.2
+    - android-21
 
 branches:
   only:
@@ -43,6 +56,10 @@ branches:
 
 # We can be run in a container for improved performance.
 sudo: false
+
+cache:
+  # This is only supported on Linux as it requires containers
+  # Linux automatically caches localJ2objcDist and the JDK install
 
 before_install:
   # Don't spew graphic art.
@@ -65,7 +82,7 @@ install:
   - ./gradlew wrapper
   - ./gradlew dependencies
   # Prepare our system tests
-  - if [ "$USING_OS" = "osx" ]; then systemTests/install.sh; fi
+  - systemTests/install.sh
 
 # If these steps fail, the build is 'failed' - i.e. we have a code defect.
 # We compile (assemble) and then build (which also tests) to capture build
@@ -74,4 +91,4 @@ script:
   - ./gradlew assemble
   - ./gradlew build
   # Run our system tests
-  - if [ "$USING_OS" = "osx" ]; then systemTests/run-all.sh $TEST_SET; fi
+  - systemTests/run-all.sh $TEST_SET

--- a/systemTests/allPlatforms/settings.gradle
+++ b/systemTests/allPlatforms/settings.gradle
@@ -1,1 +1,6 @@
-include ':shared', ':app'
+include ':shared'
+
+// Travis CI doesn't support Android on OS X
+if (!System.getenv('ANDROID_BUILD_DISABLED').equals('true')) {
+    include ':app'
+}

--- a/systemTests/install.sh
+++ b/systemTests/install.sh
@@ -36,6 +36,11 @@ pushd localJ2objcDist
 # Default is version number listed on following line:
 J2OBJC_VERSION=${J2OBJC_VERSION:=0.9.8.2.1}
 
+# Specific version can be configured from command line:
+# export ANDROID_HOME=DIR
+# Default is for Travis default location, listed on following line:
+ANDROID_HOME=${ANDROID_HOME:=/usr/local/android-sdk}
+
 echo "J2OBJC Version: $J2OBJC_VERSION"
 
 DIST_DIR=j2objc-$J2OBJC_VERSION
@@ -43,10 +48,19 @@ DIST_FILE=$DIST_DIR.zip
 
 # For developer local testing, don't keep redownloading the zip file.
 if [ ! -e $DIST_FILE ]; then
-  curl -L https://github.com/google/j2objc/releases/download/$J2OBJC_VERSION/j2objc-$J2OBJC_VERSION.zip > $DIST_FILE
-  unzip $DIST_FILE
-  echo j2objc.home=$PWD/$DIST_DIR > ../common/local.properties
-  echo "local.properties configured: j2objc.home=$PWD/$DIST_DIR"
+   curl -L https://github.com/google/j2objc/releases/download/$J2OBJC_VERSION/j2objc-$J2OBJC_VERSION.zip > $DIST_FILE
+   unzip -q $DIST_FILE
+
+   # systemTests/common/local.properties
+   echo j2objc.home=$PWD/$DIST_DIR > ../common/local.properties
+   if [ "${ANDROID_BUILD_DISABLED:=false}" != "true" ]; then
+      echo sdk.dir=$ANDROID_HOME >> ../common/local.properties
+   fi
+   if [ "${J2OBJC_TRANSLATE_ONLY:=false}" == "true" ]; then
+      echo j2objc.translateOnlyMode=true >> ../common/local.properties
+   fi
+   echo "systemTests/common/local.properties configured:"
+   cat ../common/local.properties
 fi
 
 # pop localJ2objcDist

--- a/systemTests/run-all.sh
+++ b/systemTests/run-all.sh
@@ -14,18 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Fail if anything fails.
+set -uev
 
-set -ev
-
-# Two test sets; if no test set is specified (as the first arg),
-# all tests will run.
 # Add new tests to whichever set takes the least time to run on Travis.
 # If any test set is nearing ~45 minutes to build, you must make a new
 # test set and also update .travis.yml.
-TEST_SET=$1
 
-# Fail if anything fails.
-set -euv
+# Defaults to "12", which runs both tests
+# Run specific test by script parameter, e.g. 'systemTests/run-all.sh 1'
+TEST_SET=${1:-12}
 
 J2OBJC_VERSION=${J2OBJC_VERSION:=0.9.8.2.1}
 
@@ -34,21 +32,23 @@ if [[ "$PWD" =~ systemTests ]]; then
    exit 1
 fi
 
-if [ -z "$TEST_SET" ] || [ "$TEST_SET" == "1" ] ; then
+if [[ $TEST_SET == *"1"* ]] ; then
    echo Running test set 1
 
    # Simplest possible set-up.  A single project with no dependencies.
    systemTests/run-test.sh systemTests/simple1
-
 
    # Two main gradle projects, `extended` depends on `base`.  They also both test
    # dependency on built-in j2objc libraries, like Guava, and build-closure
    # based translation of an external library, Gson.  They also both depend
    # depend on a third test-only gradle project, `testLib`.
    systemTests/run-test.sh systemTests/multiProject1
+
+   # Platform specific app build: Android, iOS, OS X and some day watchOS
+   systemTests/run-test.sh systemTests/allPlatforms
 fi
 
-if [ -z "$TEST_SET" ] || [ "$TEST_SET" == "2" ] ; then
+if [[ $TEST_SET == *"2"* ]] ; then
    echo Running test set 2
 
    # Two gradle projects, `extended` depends on `base`. Both of them depend


### PR DESCRIPTION
- Add allPlatforms to run-all.sh
- ANDROID_HOME env variable, Travis default: `/usr/local/android-sdk`
- Gradle allPlatforms/build.gradle => disable Android builds on OS X
- Fix run-all.sh so that without any parameter it will default to all

Travis config:
- Linux / oraclejdk7 => no tests (same as before)
- Linux / openjdk7 => TEST_SET=1 (also J2OBJC_TRANSLATE_ONLY)
- OS X => ANDROID_BUILD_DISABLED (using settings.gradle)

Android environment:
- android-21
- build-tools-21.1.2