### PR TITLE
convert podMethodName to valid Ruby

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -102,7 +102,8 @@ class XcodeTask extends DefaultTask {
         }
 
         String getPodMethodName() {
-            return "j2objc_$projectName"
+            // Valid Ruby name requires replacing all non-alphanumeric characters with underscore
+            return "j2objc_$projectName".replaceAll(/[^a-zA-Z0-9]/, '_')
         }
 
         @SuppressWarnings('unused')

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -64,7 +64,7 @@ class XcodeTaskTest {
     }
 
     @Test
-    void testPodspecDetailsSerialization() {
+    void testPodspecDetails_serialization() {
         // From: http://stackoverflow.com/a/9775330/1509221
         XcodeTask.PodspecDetails podspecDetailsIn = new XcodeTask.PodspecDetails(
                 'pname', new File('fileDebug'), new File('fileRelease'))
@@ -83,6 +83,15 @@ class XcodeTaskTest {
         assert 'pname' == podspecDetailsOut.projectName
         assert 'fileDebug' == podspecDetailsOut.podspecDebug.path
         assert 'fileRelease' == podspecDetailsOut.podspecRelease.path
+    }
+
+    @Test
+    // Check that the project name is converted to a valid ruby method name
+    // http://stackoverflow.com/a/10542599/1509221
+    void testPodspecDetails_getPodMethodName_validForRuby() {
+        XcodeTask.PodspecDetails podspecDetails = new XcodeTask.PodspecDetails(
+                'project-NAME_09.!?=', null, null)
+        assert 'j2objc_project_NAME_09____' == podspecDetails.getPodMethodName()
     }
 
     @Test


### PR DESCRIPTION
- Replace all non-alphanumeric characters with underscore
- Fixes #538