### PR TITLE
README revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ so you can write an app's non-UI code (such as application logic and data models
 which is then shared by Android apps (natively Java) and iOS apps (using J2ObjC).
 
 The plugin:
-* translates your Java source code to Objective-C for iOS (iPhone/iPad) using [__J2ObjC__](https://github.com/google/j2objc), an open-source tool from Google
-* builds Objective-C static libraries and headers ready-to-use in Xcode
-* runs translated versions of your JUnit tests to ensure your code works in Objective-C form
-* handles multiple Java projects, external Java libraries \[1\], and existing Objective-C code you'd like to link in
-* configures Xcode projects to use your translated libraries, using CocoaPods (optionally)
+* Translates your Java source code to Objective-C for iOS (iPhone/iPad) using [__J2ObjC__](https://github.com/google/j2objc), an open-source tool from Google
+* Builds Objective-C static libraries and headers ready-to-use in Xcode
+* Runs translated versions of your JUnit tests to ensure your code works in Objective-C form
+* Handles multiple Java projects, external Java libraries \[1\], and existing Objective-C code you'd like to link in
+* Configures Xcode projects to use your translated libraries, using CocoaPods (optionally)
  
 The plugin is not affiliated with Google but was developed by former Google Engineers and others.
 Note that the plugin is currently in alpha; we may need to make breaking API changes
@@ -132,13 +132,13 @@ Please first check the [Frequently Asked Questions](FAQ.md).
 
 Next, search the [Issues](https://github.com/j2objc-contrib/j2objc-gradle/issues) for a similar
 problem.  If your issue is not addressed, please file a new Issue, including the following
-details (if you are comfortable sharing publicly as "Contribution(s)" per
-the [LICENSE](LICENSE)):
+details:
 - build.gradle file(s)
 - contents of Gradle build errors if any
 - version of J2ObjC you have installed
 
 If you are not comfortable sharing these, the community may not be able to help as much.
+Please note your bug reports will be treated as "Contribution(s)" per the [LICENSE](LICENSE).
 
 Mozilla's [Bug writing guidelines](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Bug_writing_guidelines)
 may be helpful. Having public, focused, and actionable Issues
@@ -164,4 +164,4 @@ J2ObjC and libraries distributed with J2ObjC are under their own licenses.
 
 ### Footnotes
 
-[1].  <a href='#footnote1'>where source is appropriately licensed and available</a>
+[1]  <a href='#footnote1'>where source is appropriately licensed and available</a>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The plugin:
 * translates your Java source code to Objective-C for iOS (iPhone/iPad) using [__J2ObjC__](https://github.com/google/j2objc), an open-source tool from Google
 * builds Objective-C static libraries and headers ready-to-use in Xcode
 * runs translated versions of your JUnit tests to ensure your code works in Objective-C form
-* handles multiple Java projects, external Java libraries (where source is appropriately licensed and available), and existing Objective-C code you'd like to link in
-* configures your Xcode projects to use your translated code, without requiring manual editing of the generated files (optionally, when using CocoaPods)
+* handles multiple Java projects, external Java libraries \[1\], and existing Objective-C code you'd like to link in
+* configures Xcode projects to use your translated libraries, using CocoaPods (optionally)
  
 The plugin is not affiliated with Google but was developed by former Google Engineers and others.
 Note that the plugin is currently in alpha; we may need to make breaking API changes
@@ -23,7 +23,7 @@ Home Page: https://github.com/j2objc-contrib/j2objc-gradle
 
 ### Quick Start Guide
 
-You should start with a clean java only project without any Android dependencies.
+You should start with a clean Java only project without any Android dependencies.
 It is suggested that the project is named `shared`. It must be buildable using the standard
 [Gradle Java plugin](https://docs.gradle.org/current/userguide/java_plugin.html).
 Starting with an empty project allows you to gradually shift over code from an existing
@@ -44,9 +44,7 @@ plugins {
 }
 
 dependencies {
-    compile 'com.google.j2objc:j2objc-annotations:0.9.8'
-    
-    // Any other standard libraries you depend on, like Guava or JUnit
+    // Any libraries you depend on, like Guava or JUnit
     compile 'com.google.guava:guava:18.0'
     testCompile 'junit:junit:4.11'
 }
@@ -64,14 +62,6 @@ j2objcConfig {
 }
 ```
 
-For more complex situations like:
-* building for OS X and ([soon](https://github.com/j2objc-contrib/j2objc-gradle/issues/525)) watchOS
-* [multiple Java projects and third-party libraries](FAQ.md#how-do-i-setup-dependencies-with-j2objc)
-* customizing the translation and compilation steps
-
-, check the [FAQ table of contents](FAQ.md) or see all of the `j2objcConfig` settings in
-[J2objcConfig.groovy](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L30).
-
 Finally, make the Android application's `android/build.gradle` depend on the `shared` project:
 
 ```gradle
@@ -80,6 +70,16 @@ dependencies {
     compile project(':shared')
 }
 ```
+
+For more complex situations like:
+* building for OS X and ([soon](https://github.com/j2objc-contrib/j2objc-gradle/issues/525)) watchOS
+* [multiple Java projects and third-party libraries](FAQ.md#how-do-i-setup-dependencies-with-j2objc)
+* customizing the translation and compilation steps
+* mixing Objective-C and Java implementations
+
+, check the [FAQ table of contents](FAQ.md) or see all of the `j2objcConfig` settings in
+[J2objcConfig.groovy](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L30).
+
 
 ### Minimum Requirements
 
@@ -101,7 +101,7 @@ Applications built with the plugin may target
 
 ### J2ObjC Installation
 
-If J2ObjC is not installed when the plugin is first run, on-screen instructons will guide
+If J2ObjC is not detected when the plugin is first run, on-screen instructons will guide
 you through installation from your Terminal.
 
 Alternatively:
@@ -160,3 +160,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#quick-start).
 
 This library is distributed under the Apache 2.0 license found in the [LICENSE](./LICENSE) file.
 J2ObjC and libraries distributed with J2ObjC are under their own licenses.
+
+
+### Footnotes
+
+[1].  <a href='#footnote1'>where source is appropriately licensed and available</a>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # J2ObjC Gradle Plugin
 
-Gradle Plugin for [J2ObjC](https://github.com/google/j2objc),
-which is an open-source tool from Google that translates
-Java source code to Objective-C for the iOS (iPhone/iPad) platform. The plugin is
-not affiliated with Google but was developed by former Google Engineers and others.
-J2ObjC enables Java source to be part of an iOS application's build, no editing
-of the generated files is necessary. The goal is to write an app's non-UI code
-(such as application logic and data models) in Java, which is then shared by
-Android apps (natively Java), web apps (using GWT), and iOS apps (using J2ObjC).
+The __J2ObjC Gradle plugin__ enables Java source to be part of an iOS application's build
+so you can write an app's non-UI code (such as application logic and data models) in Java,
+which is then shared by Android apps (natively Java) and iOS apps (using J2ObjC).
+
+The plugin:
+* translates your Java source code to Objective-C for iOS (iPhone/iPad) using [__J2ObjC__](https://github.com/google/j2objc), an open-source tool from Google
+* builds Objective-C static libraries and headers ready-to-use in Xcode
+* runs translated versions of your JUnit tests to ensure your code works in Objective-C form
+* handles multiple Java projects, external Java libraries (where source is appropriately licensed and available), and existing Objective-C code you'd like to link in
+* configures your Xcode projects to use your translated code, without requiring manual editing of the generated files (optionally, when using CocoaPods)
+ 
+The plugin is not affiliated with Google but was developed by former Google Engineers and others.
+Note that the plugin is currently in alpha; we may need to make breaking API changes
+before the 1.0 release.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0%20License-blue.svg)](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/LICENSE)
 [![OSX and Linux Build Status](https://img.shields.io/travis/j2objc-contrib/j2objc-gradle/master.svg?label=mac and linux build)](https://travis-ci.org/j2objc-contrib/j2objc-gradle)
@@ -15,20 +21,20 @@ Android apps (natively Java), web apps (using GWT), and iOS apps (using J2ObjC).
 
 Home Page: https://github.com/j2objc-contrib/j2objc-gradle
 
-### Usage
+### Quick Start Guide
 
 You should start with a clean java only project without any Android dependencies.
 It is suggested that the project is named `shared`. It must be buildable using the standard
 [Gradle Java plugin](https://docs.gradle.org/current/userguide/java_plugin.html).
-Starting as an empty project allows you to gradually shift over code from an existing
+Starting with an empty project allows you to gradually shift over code from an existing
 Android application. This is beneficial for separation between the application model
-and user interface. It also allows the shared project to be easily used server side as well.
+and user interface. It also allows the shared project to be easily used server-side as well.
 
-The Android app, shared Java project and Xcode should be sibling directories, i.e children
+The Android app, shared Java project and Xcode project should be sibling directories, i.e children
 of the same root level folder. Suggested folder names are `'android', 'shared' and 'ios'`
 respectively. See the FAQ section on [recommended folder structure](FAQ.md#what-is-the-recommended-folder-structure-for-my-app).
 
-Configure `shared/build.gradle` in your Java only project:
+Configure `shared/build.gradle` for your Java-only project:
 
 ```gradle
 // File: shared/build.gradle
@@ -37,8 +43,20 @@ plugins {
     id 'com.github.j2objccontrib.j2objcgradle' version '0.4.3-alpha'
 }
 
-// Plugin settings:
+dependencies {
+    compile 'com.google.j2objc:j2objc-annotations:0.9.8'
+    
+    // Any other standard libraries you depend on, like Guava or JUnit
+    compile 'com.google.guava:guava:18.0'
+    testCompile 'junit:junit:4.11'
+}
+
+// Plugin settings; put these at the bottom of the file.
 j2objcConfig {
+    // Sets up libraries you depend on
+    autoConfigureDeps true
+    
+    // Omit these two lines if you don't configure your Xcode project with CocoaPods
     xcodeProjectDir '../ios'  //  suggested directory name
     xcodeTargetsIos 'IOS-APP', 'IOS-APPTests'  // replace with your iOS targets
 
@@ -46,15 +64,15 @@ j2objcConfig {
 }
 ```
 
-Info on additional `j2objcConfig` settings are in
-[J2objcConfig.groovy](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L30).
-The Xcode targets may also be set for xcodeTargetsOsx and xcodeTargetsWatchos
-([issue #525 to get watchOS working](https://github.com/j2objc-contrib/j2objc-gradle/issues/525)).
-If your `shared` project depends on any other projects or third-party libraries, you may
-need to [add them manually](FAQ.md#how-do-i-setup-dependencies-with-j2objc) if they aren't
-[linked by default](FAQ.md#what-libraries-are-linked-by-default).
+For more complex situations like:
+* building for OS X and ([soon](https://github.com/j2objc-contrib/j2objc-gradle/issues/525)) watchOS
+* [multiple Java projects and third-party libraries](FAQ.md#how-do-i-setup-dependencies-with-j2objc)
+* customizing the translation and compilation steps
 
-Within the Android application's `android/build.gradle`, make it dependent on the `shared` project:
+, check the [FAQ table of contents](FAQ.md) or see all of the `j2objcConfig` settings in
+[J2objcConfig.groovy](https://github.com/j2objc-contrib/j2objc-gradle/blob/master/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy#L30).
+
+Finally, make the Android application's `android/build.gradle` depend on the `shared` project:
 
 ```gradle
 // File: android/build.gradle
@@ -63,24 +81,30 @@ dependencies {
 }
 ```
 
-Note that the plugin is currently in alpha; we may need to make breaking API changes
-before the 1.0 release.
-
 ### Minimum Requirements
 
-Gradle 2.4 is required for the compilation support within Gradle. The other necessities
-are the [J2objc Requirements](http://j2objc.org/#requirements).
+The plugin requries modern versions of Gradle and J2ObjC, and assumes the
+[J2ObjC Requirements](http://j2objc.org/#requirements):
 
-    * Gradle 2.4
-    * JDK 1.7 or higher
-    * Mac workstation or laptop
-    * Mac OS X 10.9 or higher
-    * Xcode 7 or higher
-    * j2objc 0.9.8.2.1 or higher
+* Gradle 2.4
+* J2ObjC 0.9.8.2.1 or higher
+* JDK 1.7 or higher
+* Mac workstation or laptop
+* Mac OS X 10.9 or higher
+* Xcode 7 or higher
+
+Applications built with the plugin may target
+
+* iOS 6.0 or higher
+* OS X 10.6 or higher
 
 
 ### J2ObjC Installation
 
+If J2ObjC is not installed when the plugin is first run, on-screen instructons will guide
+you through installation from your Terminal.
+
+Alternatively:
 Download the latest version from the [J2ObjC Releases](https://github.com/google/j2objc/releases).
 Find (or add) the local.properties in your root folder and add the path to the unzipped folder:
 
@@ -93,7 +117,9 @@ j2objc.home=/J2OBJC_HOME
 ### Build Commands
 
 The plugin will output the generated source and libaries to the `build/j2objcOutputs`
-directory and run all tests. It is integrated with Gradle's Java build plugin and may
+directory, run all unit tests, and configure your Xcode project (if you specified one).
+
+It is integrated with Gradle's Java build plugin and may
 be run as follows:
 
     ./gradlew shared:build
@@ -103,6 +129,7 @@ be run as follows:
 
 Having issues with the plugin?
 Please first check the [Frequently Asked Questions](FAQ.md).
+
 Next, search the [Issues](https://github.com/j2objc-contrib/j2objc-gradle/issues) for a similar
 problem.  If your issue is not addressed, please file a new Issue, including the following
 details (if you are comfortable sharing publicly as "Contribution(s)" per
@@ -132,3 +159,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#quick-start).
 ### License
 
 This library is distributed under the Apache 2.0 license found in the [LICENSE](./LICENSE) file.
+J2ObjC and libraries distributed with J2ObjC are under their own licenses.


### PR DESCRIPTION
* Make it clear what this plugin actually does up-front; it has become much more than just j2objc translation.
  For users of the plugin, the execution of J2ObjC is just one implementation detail really.
* Installation instructions are in the plugin already.
* Why Gradle 2.4 (vs others) is needed is also an implementation detail.
* Mentioning GWT is irrelevant to most people.  We could just as well mention web service implementation in Java, etc.
* Show a more normal shared/build.gradle - nearly everyone depends on *some* library.
* Use bullets to break up long text