### PR TITLE
Config to only add j2objc_shared method to Podfile

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -664,8 +664,6 @@ class J2objcConfig {
      */
     String xcodeProjectDir = null
 
-    boolean onlyAddJ2ObjcToPodfile = false
-
     /**
      * iOS app and test Xcode targets to link to the generated libraries.
      *
@@ -713,6 +711,16 @@ class J2objcConfig {
     void xcodeTargetsWatchos(String... xcodeTargetsWatchos) {
         appendArgs(this.xcodeTargetsWatchos, 'xcodeTargetsWatchos', xcodeTargetsWatchos)
     }
+
+    /**
+     * Allows manual config of the Podfile (default is false).
+     *
+     * When set to true, this allows manual configuring of the Podfile targets.
+     * This is necessary when your Podfile is too complex to be automatically
+     * updated. When used, you must also set xcodeTargets{Ios|Osx|Watchos)
+     * to empty.
+     */
+    boolean xcodeTargetsManualConfig = false
 
 
     protected boolean finalConfigured = false

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -664,6 +664,8 @@ class J2objcConfig {
      */
     String xcodeProjectDir = null
 
+    boolean onlyAddJ2ObjcToPodfile = false
+
     /**
      * iOS app and test Xcode targets to link to the generated libraries.
      *

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -332,11 +332,11 @@ class XcodeTask extends DefaultTask {
         boolean endOfRegex = false
 
         for (line in podfileLines) {
-            if (!active && (line =~ startRegex).find()) {
+            if (!active && (line =~ startRegex)) {
                 active = true
                 result.addAll(newPodFileLines)
             }
-            if (active && (line =~ endRegex).find()) {
+            if (active && (line =~ endRegex)) {
                 active = false
                 endOfRegex = true
             }

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -203,7 +203,7 @@ class XcodeTask extends DefaultTask {
                 getXcodeTargetsIos(), getXcodeTargetsOsx(), getXcodeTargetsWatchos(),
                 getMinVersionIos(), getMinVersionOsx(), getMinVersionWatchos())
 
-        writeUpdatedPodfileIfNeeded(podspecDetailsList, xcodeTargetDetails, getXcodeTargetsManualConfig(), podfile)
+        writeUpdatedPodfileIfNeeded(podspecDetailsList, xcodeTargetDetails, xcodeTargetsManualConfig, podfile)
 
         // install the pod
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTask.groovy
@@ -54,7 +54,7 @@ class XcodeTask extends DefaultTask {
     String getXcodeProjectDir() { return J2objcConfig.from(project).xcodeProjectDir }
 
     @Input
-    boolean isOnlyAddJ2ObjcToPodfile() { return J2objcConfig.from(project).onlyAddJ2ObjcToPodfile }
+    boolean getXcodeTargetsManualConfig() { return J2objcConfig.from(project).xcodeTargetsManualConfig }
 
     boolean isTaskActive() { return getXcodeProjectDir() != null }
 
@@ -203,7 +203,7 @@ class XcodeTask extends DefaultTask {
                 getXcodeTargetsIos(), getXcodeTargetsOsx(), getXcodeTargetsWatchos(),
                 getMinVersionIos(), getMinVersionOsx(), getMinVersionWatchos())
 
-        writeUpdatedPodfileIfNeeded(podspecDetailsList, xcodeTargetDetails,!isOnlyAddJ2ObjcToPodfile(), podfile)
+        writeUpdatedPodfileIfNeeded(podspecDetailsList, xcodeTargetDetails, getXcodeTargetsManualConfig(), podfile)
 
         // install the pod
         ByteArrayOutputStream stdout = new ByteArrayOutputStream()
@@ -377,14 +377,15 @@ class XcodeTask extends DefaultTask {
     @VisibleForTesting
     static void writeUpdatedPodfileIfNeeded(
             List<PodspecDetails> podspecDetailsList,
-            XcodeTargetDetails xcodeTargetDetails, boolean updateTargets,
+            XcodeTargetDetails xcodeTargetDetails,
+            boolean xcodeTargetsManualConfig,
             File podfile) {
 
         List<String> oldPodfileLines = podfile.readLines()
         List<String> newPodfileLines = new ArrayList<String>(oldPodfileLines)
 
         newPodfileLines = updatePodfile(
-                newPodfileLines, podspecDetailsList, xcodeTargetDetails,updateTargets, podfile)
+                newPodfileLines, podspecDetailsList, xcodeTargetDetails, xcodeTargetsManualConfig, podfile)
 
         // Write file only if it's changed
         if (!oldPodfileLines.equals(newPodfileLines)) {
@@ -396,38 +397,49 @@ class XcodeTask extends DefaultTask {
     static List<String> updatePodfile(
             List<String> podfileLines,
             List<PodspecDetails> podspecDetailsList,
-            XcodeTargetDetails xcodeTargetDetails,boolean updateTargets,
+            XcodeTargetDetails xcodeTargetDetails,
+            boolean xcodeTargetsManualConfig,
             File podfile) {
 
-        if(updateTargets){
+        List<String> newPodfileLines = podfileLines;
+
+        boolean xcodeTargetsAllEmpty =
+                xcodeTargetDetails.xcodeTargetsIos.isEmpty() &&
+                        xcodeTargetDetails.xcodeTargetsOsx.isEmpty() &&
+                        xcodeTargetDetails.xcodeTargetsWatchos.isEmpty()
+
+        if (xcodeTargetsManualConfig) {
+            if (!xcodeTargetsAllEmpty) {
+                throw new InvalidUserDataException(
+                        "Xcode targets must all be blank when using xcodeTargetsManualConfig.\n" +
+                                "Please update j2objcConfig by removing xcodeTargetsIos, xcodeTargetsOsx & xcodeTargetsWatchos")
+            }
+        } else {
+            // xcodeTargetsManualConfig = false  (default)
             List<String> podfileTargets = extractXcodeTargets(podfileLines)
             verifyTargets(xcodeTargetDetails.xcodeTargetsIos, podfileTargets, 'xcodeTargetsIos')
             verifyTargets(xcodeTargetDetails.xcodeTargetsOsx, podfileTargets, 'xcodeTargetsOsx')
             verifyTargets(xcodeTargetDetails.xcodeTargetsWatchos, podfileTargets, 'xcodeTargetsWatchos')
 
             if (xcodeTargetDetails.xcodeTargetsIos.isEmpty() &&
-                xcodeTargetDetails.xcodeTargetsOsx.isEmpty() &&
-                xcodeTargetDetails.xcodeTargetsWatchos.isEmpty()) {
+                    xcodeTargetDetails.xcodeTargetsOsx.isEmpty() &&
+                    xcodeTargetDetails.xcodeTargetsWatchos.isEmpty()) {
                 // Give example for configuring iOS as that's the common case
                 throw new InvalidUserDataException(
                         "You must configure the xcode targets for the J2ObjC Gradle Plugin.\n" +
-                        "It must be a subset of the valid targets: '${podfileTargets.join("', '")}'\n" +
-                        "\n" +
-                        "j2objcConfig {\n" +
-                        "    xcodeTargetsIos 'IOS-APP', 'IOS-APPTests'  // example\n" +
-                        "}\n" +
-                        "\n" +
-                        "Can be optionally configured for xcodeTargetsOsx and xcodeTargetsWatchos\n")
+                                "It must be a subset of the valid targets: '${podfileTargets.join("', '")}'\n" +
+                                "\n" +
+                                "j2objcConfig {\n" +
+                                "    xcodeTargetsIos 'IOS-APP', 'IOS-APPTests'  // example\n" +
+                                "}\n" +
+                                "\n" +
+                                "Can be optionally configured for xcodeTargetsOsx and xcodeTargetsWatchos\n")
             }
+            newPodfileLines = updatePodfileTargets(newPodfileLines, podspecDetailsList, xcodeTargetDetails)
         }
 
         // update pod methods
-        List<String> newPodfileLines = updatePodMethods(podfileLines, podspecDetailsList, podfile)
-
-        // update pod targets
-        if(updateTargets){
-             newPodfileLines = updatePodfileTargets(newPodfileLines, podspecDetailsList, xcodeTargetDetails)
-        }
+        newPodfileLines = updatePodMethods(newPodfileLines, podspecDetailsList, podfile)
 
         return newPodfileLines
     }
@@ -437,7 +449,8 @@ class XcodeTask extends DefaultTask {
             if (! podfileTargets.contains(xcodeTarget)) {
                 throw new InvalidUserDataException(
                         "Invalid j2objcConfig { $xcodeTargetsName '$xcodeTarget' }\n" +
-                        "Must be one of the valid targets: '${podfileTargets.join("', '")}'")
+                                "Must be one of the valid targets: '${podfileTargets.join("', '")}'\n" +
+                                "NOTE: if your Podfile is too complex, you may need to use xcodeTargetsManualConfig")
             }
         }
     }

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -46,6 +46,9 @@ class XcodeTaskTest {
                 'PROJ',
                 new File('/SRC/PROJ/BUILD/j2objc-PROJ-debug.podspec'),
                 new File('/SRC/PROJ/BUILD/j2objc-PROJ-release.podspec'))]
+    XcodeTask.XcodeTargetDetails xcodeTargetDetailsEmpty =
+            new XcodeTask.XcodeTargetDetails(
+                    [], [], [],null,null,null)
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -430,7 +433,7 @@ class XcodeTaskTest {
                 new File(podspecBuildDir + '/j2objc-PROJ-debug.podspec'),
                 new File(podspecBuildDir + '/j2objc-PROJ-release.podspec')))
         XcodeTask.writeUpdatedPodfileIfNeeded(
-                podspecDetailsList, xcodeTargetDetailsIosAppOnly, true, podfile)
+                podspecDetailsList, xcodeTargetDetailsIosAppOnly, false, podfile)
 
         // Verify modified Podfile
         List<String> expectedLines = [
@@ -451,7 +454,7 @@ class XcodeTaskTest {
         // Verify unmodified on second call
         // TODO: verify that file wasn't written a second time
         XcodeTask.writeUpdatedPodfileIfNeeded(
-                podspecDetailsList, xcodeTargetDetailsIosAppOnly, true, podfile)
+                podspecDetailsList, xcodeTargetDetailsIosAppOnly, false, podfile)
         readPodfileLines = podfile.readLines()
         assert expectedLines == readPodfileLines
     }
@@ -465,7 +468,8 @@ class XcodeTaskTest {
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly, true,
+                xcodeTargetDetailsIosAppOnly,
+                false,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedPodfileLines = [
@@ -485,13 +489,14 @@ class XcodeTaskTest {
         newPodfileLines = XcodeTask.updatePodfile(
                 newPodfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly, true,
+                xcodeTargetDetailsIosAppOnly,
+                false,
                 new File('/SRC/ios/Podfile'))
         assert expectedPodfileLines == newPodfileLines
     }
 
     @Test
-    void testUpdatePodfile_onlyAddMethod() {
+    void testUpdatePodfile_xcodeTargetsManualConfig() {
         List<String> podfileLines = [
                 "target 'IOS-APP' do",
                 "end"]
@@ -499,7 +504,8 @@ class XcodeTaskTest {
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly, false,
+                xcodeTargetDetailsEmpty ,
+                true,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedPodfileLines = [
@@ -517,7 +523,8 @@ class XcodeTaskTest {
         newPodfileLines = XcodeTask.updatePodfile(
                 newPodfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly, false,
+                xcodeTargetDetailsEmpty,
+                true,
                 new File('/SRC/ios/Podfile'))
         assert expectedPodfileLines == newPodfileLines
     }
@@ -541,7 +548,8 @@ class XcodeTaskTest {
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetails, true,
+                xcodeTargetDetails,
+                false,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedPodfileLines = [
@@ -571,7 +579,8 @@ class XcodeTaskTest {
         newPodfileLines = XcodeTask.updatePodfile(
                 newPodfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetails, true,
+                xcodeTargetDetails,
+                false,
                 new File('/SRC/ios/Podfile'))
         assert expectedPodfileLines == newPodfileLines
     }
@@ -594,7 +603,8 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         [], [], [],
-                        '6.0.0', '10.6.0', '1.0.0'), true,
+                        '6.0.0', '10.6.0', '1.0.0'),
+                false,
                 null)
     }
 
@@ -615,7 +625,8 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         ['TARGET-DOES-NOT-EXIST'], [], [],
-                        '6.0.0', '10.6.0', '1.0.0'), true,
+                        '6.0.0', '10.6.0', '1.0.0'),
+                false,
                 null)
     }
 
@@ -625,7 +636,8 @@ class XcodeTaskTest {
 
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines, podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly, false,
+                xcodeTargetDetailsEmpty,
+                true,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedLines = [

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/XcodeTaskTest.groovy
@@ -430,7 +430,7 @@ class XcodeTaskTest {
                 new File(podspecBuildDir + '/j2objc-PROJ-debug.podspec'),
                 new File(podspecBuildDir + '/j2objc-PROJ-release.podspec')))
         XcodeTask.writeUpdatedPodfileIfNeeded(
-                podspecDetailsList, xcodeTargetDetailsIosAppOnly, podfile)
+                podspecDetailsList, xcodeTargetDetailsIosAppOnly, true, podfile)
 
         // Verify modified Podfile
         List<String> expectedLines = [
@@ -451,7 +451,7 @@ class XcodeTaskTest {
         // Verify unmodified on second call
         // TODO: verify that file wasn't written a second time
         XcodeTask.writeUpdatedPodfileIfNeeded(
-                podspecDetailsList, xcodeTargetDetailsIosAppOnly, podfile)
+                podspecDetailsList, xcodeTargetDetailsIosAppOnly, true, podfile)
         readPodfileLines = podfile.readLines()
         assert expectedLines == readPodfileLines
     }
@@ -465,7 +465,7 @@ class XcodeTaskTest {
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly,
+                xcodeTargetDetailsIosAppOnly, true,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedPodfileLines = [
@@ -485,7 +485,39 @@ class XcodeTaskTest {
         newPodfileLines = XcodeTask.updatePodfile(
                 newPodfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetailsIosAppOnly,
+                xcodeTargetDetailsIosAppOnly, true,
+                new File('/SRC/ios/Podfile'))
+        assert expectedPodfileLines == newPodfileLines
+    }
+
+    @Test
+    void testUpdatePodfile_onlyAddMethod() {
+        List<String> podfileLines = [
+                "target 'IOS-APP' do",
+                "end"]
+
+        List<String> newPodfileLines = XcodeTask.updatePodfile(
+                podfileLines,
+                podspecDetailsProj,
+                xcodeTargetDetailsIosAppOnly, false,
+                new File('/SRC/ios/Podfile'))
+
+        List<String> expectedPodfileLines = [
+                "# J2ObjC Gradle Plugin - DO NOT MODIFY from here to the first target",
+                "def j2objc_PROJ",
+                "    pod 'j2objc-PROJ-debug', :configuration => ['Debug'], :path => '../PROJ/BUILD'",
+                "    pod 'j2objc-PROJ-release', :configuration => ['Release'], :path => '../PROJ/BUILD'",
+                "end",
+                "",
+                "target 'IOS-APP' do",
+                "end"]
+        assert expectedPodfileLines == newPodfileLines
+
+        // Second time around is a no-op
+        newPodfileLines = XcodeTask.updatePodfile(
+                newPodfileLines,
+                podspecDetailsProj,
+                xcodeTargetDetailsIosAppOnly, false,
                 new File('/SRC/ios/Podfile'))
         assert expectedPodfileLines == newPodfileLines
     }
@@ -509,7 +541,7 @@ class XcodeTaskTest {
         List<String> newPodfileLines = XcodeTask.updatePodfile(
                 podfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetails,
+                xcodeTargetDetails, true,
                 new File('/SRC/ios/Podfile'))
 
         List<String> expectedPodfileLines = [
@@ -539,7 +571,7 @@ class XcodeTaskTest {
         newPodfileLines = XcodeTask.updatePodfile(
                 newPodfileLines,
                 podspecDetailsProj,
-                xcodeTargetDetails,
+                xcodeTargetDetails, true,
                 new File('/SRC/ios/Podfile'))
         assert expectedPodfileLines == newPodfileLines
     }
@@ -562,7 +594,7 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         [], [], [],
-                        '6.0.0', '10.6.0', '1.0.0'),
+                        '6.0.0', '10.6.0', '1.0.0'), true,
                 null)
     }
 
@@ -583,8 +615,27 @@ class XcodeTaskTest {
                 [],
                 new XcodeTask.XcodeTargetDetails(
                         ['TARGET-DOES-NOT-EXIST'], [], [],
-                        '6.0.0', '10.6.0', '1.0.0'),
+                        '6.0.0', '10.6.0', '1.0.0'), true,
                 null)
+    }
+
+    @Test
+    void testUpdatePodfileNoTargets_onlyAddMethod() {
+        List<String> podfileLines = []
+
+        List<String> newPodfileLines = XcodeTask.updatePodfile(
+                podfileLines, podspecDetailsProj,
+                xcodeTargetDetailsIosAppOnly, false,
+                new File('/SRC/ios/Podfile'))
+
+        List<String> expectedLines = [
+                "# J2ObjC Gradle Plugin - DO NOT MODIFY from here to the first target",
+                "def j2objc_PROJ",
+                "    pod 'j2objc-PROJ-debug', :configuration => ['Debug'], :path => '../PROJ/BUILD'",
+                "    pod 'j2objc-PROJ-release', :configuration => ['Release'], :path => '../PROJ/BUILD'",
+                "end"]
+
+        assert expectedLines == newPodfileLines
     }
 
     @Test


### PR DESCRIPTION
@brunobowden 
I started working on issue #561. This is not finished. I just opened this PR already to get some feedback if I am on the right track. 

My idea was: Add an extra property that can disable updating the targets. Default will be as it is. If the property is set, it will disable all checks for targets and only add/update the j2objc method to the Podfile. Is that the intention?

My questions: 
naming: since you renamed the ticket I guess you prefer the naming to be something about "only to add the method" instead of "disabling updating of the target"? in the task I used updateTargets now as a boolean since that seemed more straight forward. Is that ok?
So far the method is always added before the target instructions. Where should it go if this cannot be found? Is it possible to just add it at the beginning of the file? Maybe before the 'source ...' ?