### PR TITLE
Changelog links + end-to-end update as part of release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
-To see everything that has changed between version vA.B.C and vX.Y.Z, visit:
-https://github.com/j2objc-contrib/j2objc-gradle/compare/vA.B.C...vX.Y.Z
+The following link can be adapted to see the differences between two versions.
+Example is given for differences between `v0.5.0-alpha` and `v0.6.0-alpha`:
+
+https://github.com/j2objc-contrib/j2objc-gradle/compare/v0.5.0-alpha...v0.6.0-alpha
+
+
+The list of releases with working links is most easily viewed here:
+
+https://github.com/j2objc-contrib/j2objc-gradle/releases
+
 
 Change numbers below are github.com pull requests; peruse #NNN at:
+
 https://github.com/j2objc-contrib/j2objc-gradle/pull/NNN
+
 
 # Prerelease Alphas
 
@@ -32,7 +42,7 @@ Fixes:
 * Several broken links from plugin #563
 
 Code quality:
-* Guava 19.0 system test (updated from Guava 18.0)
+* Guava 19.0 system test (updated from Guava 18.0) #434
 
 
 ## v0.5.0-alpha

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,13 +433,17 @@ verify that no additional commits/PRs have been merged that you don't want in th
 git tag -a v0.4.1-alpha cfdc1aa
 git push upstream v0.4.1-alpha
 ```
-6.  Do a clean build and then publish the new version to https://plugins.gradle.org<br>
+6. Do a clean build and then publish the new version to https://plugins.gradle.org<br>
 ```sh
 ./gradlew clean build publishPlugins
 ```
-7.  Push a new PR that increments build.gradle to `vX.Y.(Z+1)-SNAPSHOT`.  `-SNAPSHOT`
+7. Push a new PR that increments build.gradle to `vX.Y.(Z+1)-SNAPSHOT`.  `-SNAPSHOT`
 is standard convention for marking an unofficial build (if users happen to get their
 hands on one built directly from source).
+8. Update j2objc-common-libs-e2e-test to use the latest plugin version,
+[see instructions](https://github.com/j2objc-contrib/j2objc-common-libs-e2e-test/blob/master/CONTRIBUTING.md#updating-j2objc-gradle).
+The commit SHA should match the SHA shown in the PR.
+
 
 ### Hotfixes
 


### PR DESCRIPTION
- Changelog PR references are now links
- Version comparison link gives an example
- Release process now includes updating end-to-end repo