### PR TITLE
Customization of Xcode build configuration names

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -32,6 +32,7 @@ Paste the results below, replacing existing contents.
 - [Why is my clean build failing?](#why-is-my-clean-build-failing)
 - [How do I include Java files from additional source directories?](#how-do-i-include-java-files-from-additional-source-directories)
 - [How do I develop with Swift?](#how-do-i-develop-with-swift)
+- [How do I specify additional Xcode build configurations?](#how-do-i-specify-additional-xcode-build-configurations)
 - [How do I manually configure the Cocoapods Podfile?](#how-do-i-manually-configure-the-cocoapods-podfile)
 - [How do I manually configure my Xcode project to use the translated libraries?](#how-do-i-manually-configure-my-xcode-project-to-use-the-translated-libraries)
 - [How do I update my J2ObjC translated code from Xcode?](#how-do-i-update-my-j2objc-translated-code-from-xcode)
@@ -333,6 +334,27 @@ you'd like to access from Swift code.
 // Included from `shared/build/j2objcOutputs/src/main/objc`
 #import "MyClassOne.h"
 #import "MyClassTwo.h"
+```
+
+
+### How do I specify additional Xcode build configurations?
+
+Set `xcodeDebugConfigurations` and `xcodeReleaseConfigurations` to specify which build
+configurations should link the debug and release builds of the translated libs, respectively.
+These default to `['Debug']` and `['Release']` which correspond to Xcode's default build
+configuration names. Setting either of these to an empty array will omit the respective pod
+line from the "pod method".
+
+For example, if you have a build configuration called "Beta" for sending to internal testers
+and one called "Preview" for doing ad-hoc distribution:
+
+```gradle
+// File: shared/build.gradle
+j2objcConfig {
+    xcodeDebugConfigurations += ['Beta']
+    xcodeReleaseConfigurations += ['Preview']
+    ...
+}
 ```
 
 

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -725,6 +725,33 @@ class J2objcConfig {
      */
     boolean xcodeTargetsManualConfig = false
 
+    /**
+     * The Xcode build configurations which should link to the generated debug libraries.
+     * If set to an empty array, the Debug configuration will be omitted from the "pod method".
+     * <p/>
+     * For example:
+     * <pre>
+     * j2objcConfig {
+     *     xcodeDebugConfigurations += ['Beta']
+     *     ...
+     * }
+     * </pre>
+     */
+    List<String> xcodeDebugConfigurations = ['Debug']
+
+    /**
+     * The Xcode build configurations which should link to the generated release libraries.
+     * If set to an empty array, the Release configuration will be omitted from the "pod method".
+     * <p/>
+     * For example:
+     * <pre>
+     * j2objcConfig {
+     *     xcodeReleaseConfigurations += ['Preview']
+     *     ...
+     * }
+     * </pre>
+     */
+    List<String> xcodeReleaseConfigurations = ['Release']
 
     protected boolean finalConfigured = false
     /**

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -511,6 +511,14 @@ class Utils {
         return null
     }
 
+    static String toQuotedList(List<String> listString) {
+        if (listString.isEmpty()) {
+            return ''
+        } else {
+            return "'${listString.join("','")}'"
+        }
+    }
+
     @VisibleForTesting
     static String projectExecLog(
             ExecSpec execSpec, ByteArrayOutputStream stdout, ByteArrayOutputStream stderr,

--- a/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
+++ b/src/test/groovy/com/github/j2objccontrib/j2objcgradle/tasks/UtilsTest.groovy
@@ -498,6 +498,14 @@ class UtilsTest {
     }
 
     @Test
+    void testToQuotedString() {
+        assert "'a','b','c'" == Utils.toQuotedList(['a', 'b', 'c'])
+        assert "'abc'" == Utils.toQuotedList(['abc'])
+        assert "''" == Utils.toQuotedList([''])
+        assert "" == Utils.toQuotedList([])
+    }
+
+    @Test
     void testProjectExecLog() {
         ExecSpec execSpec = new ExecHandleBuilder()
         execSpec.setExecutable('/EXECUTABLE')


### PR DESCRIPTION
Patch for issue #588.

Adds two new configs, `podfileDebugConfigurations` and `podfileReleaseConfigurations`, to allow customization of the Xcode build configuration names that are specified in the Podfile as linking with the debug and release translated libs. These default to the previously hardcoded `['Debug']` and `['Release']`.