### PR TITLE
Added convenient property for disabling the required version check,

### DIFF
--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -848,7 +848,8 @@ class J2objcConfig {
         }
         // Yes, J2ObjC uses stderr to output the version.
         String actualVersionString = stderr.toString().trim()
-        if (actualVersionString != "j2objc $j2objcVersion".toString()) {
+        boolean overrideRequiredVersion = Utils.getLocalProperty(project, 'version.override', 'false').toBoolean()
+        if (actualVersionString != "j2objc $j2objcVersion".toString() && !overrideRequiredVersion) {
             // Note that actualVersionString will usually already have the word 'j2objc' in it.
             Utils.throwJ2objcConfigFailure(project,
                     "Found $actualVersionString at $j2objcHome, J2ObjC v$j2objcVersion required.")

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/tasks/Utils.groovy
@@ -240,7 +240,8 @@ class Utils {
         'enabledArchs',
         'home',
         'release.enabled',
-        'translateOnlyMode'
+        'translateOnlyMode',
+        'version.override'
     ))
 
     private static final String PROPERTY_KEY_PREFIX = 'j2objc.'


### PR DESCRIPTION
for testing new j2objc versions, e.g. 1.0.1 and/or local j2objc builds.

local.properties:

...
j2objc.version.override=true
...
