### PR TITLE
Allow spaces in translate paths

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,6 +11,7 @@ Main Contributors:
 Thanks:
   Peter Niederweiser @pniederw <peter@pniederw.com>
   Sterling Greene @big-guy <sterling.greene@gradleware.com>
+  Daniel Dickison @danieldickison <danieldickison@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this software except in compliance with the License.

--- a/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
+++ b/src/main/groovy/com/github/j2objccontrib/j2objcgradle/J2objcConfig.groovy
@@ -228,7 +228,7 @@ class J2objcConfig {
      *  @param translateClasspaths add libraries for -classpath argument
      */
     void translateClasspaths(String... translateClasspaths) {
-        appendArgs(this.translateClasspaths, 'translateClasspaths', true, translateClasspaths)
+        appendArgs(this.translateClasspaths, 'translateClasspaths', false, translateClasspaths)
     }
 
     /**
@@ -241,7 +241,7 @@ class J2objcConfig {
      *  @param translateSourcepaths args add source jar for translation
      */
     void translateSourcepaths(String... translateSourcepaths) {
-        appendArgs(this.translateSourcepaths, 'translateSourcepaths', true, translateSourcepaths)
+        appendArgs(this.translateSourcepaths, 'translateSourcepaths', false, translateSourcepaths)
     }
 
     /**


### PR DESCRIPTION
Allow spaces in the arguments to translateClasspaths and translateSourcepaths. I think spaces in these arguments are valid and, on a more immediate concern, this works around an error I see after upgrading to Android Studio 2 beta 6 that says:

```
Error:(74, 0) '/Applications/Android Studio.app/Contents/gradle/m2repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar' argument should not contain spaces and be written out as distinct entries:
translateSourcepaths '/Applications/Android', 'Studio.app/Contents/gradle/m2repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar'
```

I, Daniel Dickison (danieldickison@gmail.com, https://github.com/danieldickison), certify that
a) this Contribution is my original work, and
b) I have the right to submit this Contribution under the Apache License,
   Version 2.0 (the "License") available at
   http://www.apache.org/licenses/LICENSE-2.0, and
c) I am submitting this Contribution under the License.
